### PR TITLE
Add matching capability to Rule instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: node_js
+
 node_js:
-    - "0.10.29"
-    - "0.10"
-    - "0.12"
-    - "4.2"
+  - "0.10"
+  - "0.12"
+  - "4.2"
+  - "5"
+
+env:
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 sudo: false
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -8,10 +8,153 @@ var Template = HyperSwitch.Template;
 function Rule(name, spec) {
 
     this.name = name;
-    this.spec = spec;
-    this._processRule(); 
+    this.spec = spec || {};
+    this.exec = [];
+    this.topic = '';
+    this.match = {
+        all: true,
+        test: '',
+        obj: {}
+    };
+    this.noop = false;
+
+    this._processRule();
 
 }
+
+
+/**
+ * Tests the message against the compiled evaluation test
+ *
+ * @param {Object} message the message to test
+ * @return true if no match is set for this rule or if the message matches
+ */
+Rule.prototype.test = function(message) {
+
+    return this.match.all || this._match_test(message);
+
+};
+
+
+/**
+ * Expands the rule's match object with the given message's content
+ *
+ * @param {Object} message the message to use in the expansion
+ * @return {Object} the object containing the expanded match portion of the rule
+ */
+Rule.prototype.expand = function(message) {
+
+    return this._match_expand(message);
+
+};
+
+
+Rule.prototype._match_test = function(message) {
+
+    // NOTE: this method gets overriden by
+    // each Rule instance with a defined match object
+    return false;
+
+};
+
+
+Rule.prototype._match_expand = function(message) {
+
+    // NOTE: this method gets overriden by
+    // each Rule instance with a defined match object
+    return {};
+
+};
+
+
+Rule.prototype._compileMatch = function(obj, result, name, fieldName) {
+
+    var self = this;
+
+    if (obj.constructor !== Object) {
+        if (typeof obj !== 'string') {
+            // not a string, so it has to match exactly
+            result[fieldName] = obj;
+            return name + ' === ' + obj;
+        }
+        if (obj[0] !== '/' && obj[obj.length - 1] !== '/') {
+            // not a regex, quote the string
+            result[fieldName] = "'" + obj + "'";
+            return name + " === '" + obj + "'";
+        }
+        // it's a regex, we have to the test the arg
+        result[fieldName] = obj + '.exec(' + name + ')';
+        return obj + '.test(' + name + ')';
+    }
+
+    // this is an object, we need to split it into components
+    var test = '';
+    var subObj = fieldName ? {} : result;
+    Object.keys(obj).forEach(function(key) {
+        var subTest = self._compileMatch(obj[key], subObj, name + "['" + key + "']", key);
+        if (test.length) {
+            test += ' && ';
+        }
+        test += subTest;
+    });
+    if (fieldName) {
+        result[fieldName] = subObj;
+    }
+
+    return test;
+
+};
+
+
+Rule.prototype._getMatchObjCode = function(obj) {
+
+    var self = this;
+    var code = '{';
+
+    if (obj.constructor !== Object) {
+        return '';
+    }
+
+    Object.keys(obj).forEach(function(key) {
+        var field = obj[key];
+        var fieldCode = key + ': ';
+        if (field.constructor === Object) {
+            fieldCode += self._getMatchObjCode(field);
+        } else {
+            fieldCode += field;
+        }
+        if (code.length > 1) {
+            code += ',';
+        }
+        code += fieldCode;
+    });
+
+    return code + '}';
+
+};
+
+
+Rule.prototype._processMatch = function() {
+
+    // no particual match specified, so we
+    // should accept all events for this topic
+    if (!this.spec.match) {
+        return;
+    }
+
+    this.match.all = false;
+    this.match.test = this._compileMatch(this.spec.match, this.match.obj, 'message');
+    try {
+        /* jslint evil: true  */
+        this._match_test = new Function('message', 'return ' + this.match.test);
+        /* jslint evil: true  */
+        this._match_expand = new Function('message', 'return ' +
+            this._getMatchObjCode(this.match.obj));
+    } catch (e) {
+        throw new Error('Invalid match object given!');
+    }
+
+};
 
 
 Rule.prototype._processRule = function() {
@@ -19,7 +162,6 @@ Rule.prototype._processRule = function() {
     var idx;
     var reqs;
     var templates = [];
-    var match = {};
 
     // validate the rule spec
     if (!this.spec.topic) {
@@ -45,6 +187,8 @@ Rule.prototype._processRule = function() {
         req.headers = req.headers || {};
         templates.push(new Template(req));
     }
+
+    this._processMatch();
 
     this.topic = this.spec.topic;
     this.exec = templates;

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -12,9 +12,7 @@ function Rule(name, spec) {
     this.exec = [];
     this.topic = '';
     this.match = {
-        all: true,
-        test: '',
-        obj: {}
+        all: true
     };
     this.noop = false;
 
@@ -136,6 +134,9 @@ Rule.prototype._getMatchObjCode = function(obj) {
 
 Rule.prototype._processMatch = function() {
 
+    var test = '';
+    var obj = {};
+
     // no particual match specified, so we
     // should accept all events for this topic
     if (!this.spec.match) {
@@ -143,13 +144,13 @@ Rule.prototype._processMatch = function() {
     }
 
     this.match.all = false;
-    this.match.test = this._compileMatch(this.spec.match, this.match.obj, 'message');
+    test = this._compileMatch(this.spec.match, obj, 'message');
     try {
         /* jslint evil: true  */
-        this._match_test = new Function('message', 'return ' + this.match.test);
+        this._match_test = new Function('message', 'return ' + test);
         /* jslint evil: true  */
         this._match_expand = new Function('message', 'return ' +
-            this._getMatchObjCode(this.match.obj));
+            this._getMatchObjCode(obj));
     } catch (e) {
         throw new Error('Invalid match object given!');
     }

--- a/test/feature/rule.js
+++ b/test/feature/rule.js
@@ -1,0 +1,119 @@
+'use strict';
+
+
+var assert = require('assert');
+var Rule = require('../../lib/rule');
+
+
+describe('Rule', function() {
+
+    it('topic required', function() {
+        assert.throws(function() {
+            var r = new Rule('rule');
+        }, Error, 'The rule should need to have a topic!');
+    });
+
+    it('no-op rule', function() {
+        var r = new Rule('noop_rule', {topic: 'nono'});
+        assert.ok(r.noop, 'The rule should be a no-op!');
+    });
+
+    it('simple rule - one request', function() {
+        var r = new Rule('rule', {
+            topic: 'nono',
+            exec: {uri: 'a/b/c'}
+        });
+        assert.ok(Array.isArray(r.exec), 'exec is expected to be an array!');
+    });
+
+    it('simple rule - multiple requests', function() {
+        var r = new Rule('rule', {
+            topic: 'nono',
+            exec: [
+                {uri: 'a/b/c'},
+                {uri: 'e/f/g/h'}
+            ]
+        });
+        assert.ok(r.exec.length === 2, 'exec is expected to have 2 elements!');
+    });
+
+    describe('Matching', function() {
+
+        var msg = {
+            meta: {
+                uri: 'a/fake/uri/for/you',
+                request_id: '12345678-9101'
+            },
+            number: 1,
+            string: 'oolala'
+        };
+
+        it('all', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'}
+            });
+            assert.ok(r.test(msg), 'Expected the rule to match all event messages!');
+        });
+
+        it('simple value match', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 1, string: 'oolala'}
+            });
+            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+        });
+
+        it('simple value mismatch', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 2, string: 'oolala'}
+            });
+            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+        });
+
+        it('regex match', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 1, string: '/(?:la)+/'}
+            });
+            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+        });
+
+        it('regex mismatch', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 1, string: '/lah/'}
+            });
+            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+        });
+
+        it('malformed match', function() {
+            assert.throws(
+                function() {
+                    var r = new Rule('rule', {
+                        topic: 'nono',
+                        exec: {uri: 'a/b/c'},
+                        match: {number: 1, string: '/l\/ah/'}
+                    });
+            }, Error);
+        });
+
+        it('expansion', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/{match.meta.uri[1]}/c'},
+                match: { meta: { uri: "/\\/fake\\/([^\\/]+)/" }, number: 1 }
+            });
+            var exp = r.expand(msg);
+            assert.deepEqual(exp.meta.uri, /\/fake\/([^\/]+)/.exec(msg.meta.uri));
+        });
+
+    });
+
+});
+


### PR DESCRIPTION
When defining a rule, the user may from now on specify a match: stanza which contains the match specification of the positive criteria to include when filtering received event messages. The match object is parsed and used in testing the incoming messages, which enter the processing pipeline iff all of the match components specified by the user match. The algorithm supports matching simple values (numbers, strings, booleans, etc.) as well as nested objects and regular expressions.

Moreover, Rule instances are also able to expand the match object using the current event message's context to give the concrete values matched in it (e.g. concrete regex results).

Example rule definition:

```yaml
topic: resource_changed
match:
  meta:
    uri: /html\/([^\/]+)(?:|\/([^\/]+))$/
  exec:
    - uri: http://localhost:7231/{message.meta.domain}/v1/page/html/{match.meta.uri[1]}/{match.meta.uri[2]}
      headers:
        cache-control: no-cache
```

Thanks to the expansion feature, one can reuse the match object and populate the request template with it.