### PR TITLE
Retry queues and explicit kafka commit

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -20,6 +20,7 @@ services:
                       topic: test_topic_simple_test_rule
                       retry_limit: 2
                       retry_delay: 10
+                      retry_on: [ 500 ]
                       match:
                         message: 'test'
                       exec:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -18,6 +18,10 @@ services:
                   templates:
                     simple_test_rule:
                       topic: test_topic_simple_test_rule
+                      retry_limit: 2
+                      retry_delay: 10
+                      match:
+                        message: 'test'
                       exec:
                         method: post
                         uri: 'http://mock.com'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -20,7 +20,10 @@ services:
                       topic: test_topic_simple_test_rule
                       retry_limit: 2
                       retry_delay: 10
-                      retry_on: [ 500 ]
+                      retry_on:
+                        status:
+                          - '50x'
+                          - 400
                       match:
                         message: 'test'
                       exec:

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -24,10 +24,8 @@ class KafkaFactory {
      * @returns {Client}
      */
     newClient() {
-        return new kafka.Client(this.kafkaConf.uri,
-        `${this.kafkaConf.clientId}-${uuid.TimeUuid.now()}-${uuid.Uuid.random()}`,
-        {}
-        );
+        const clientId = `${this.kafkaConf.clientId}-${uuid.TimeUuid.now()}-${uuid.Uuid.random()}`;
+        return new kafka.Client(this.kafkaConf.uri, clientId, {});
     }
 
     /**
@@ -58,9 +56,12 @@ class KafkaFactory {
      */
     newConsumer(client, topic, groupId, offset) {
         return new P((resolve, reject) => {
-            const consumer = new kafka.HighLevelConsumer(client, [{ topic, offset }], { groupId });
+            const consumer = new kafka.HighLevelConsumer(client, [{ topic, offset }], {
+                groupId,
+                autoCommit: false
+            });
             consumer.once('error', reject);
-            consumer.once('rebalanced', () => resolve(consumer));
+            consumer.once('rebalanced', () => resolve(P.promisifyAll(consumer)));
         });
     }
 }

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -4,17 +4,68 @@
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
 
+function _getMatchObjCode(obj) {
+    let code = '{';
+    if (obj.constructor !== Object) {
+        return '';
+    }
+    Object.keys(obj).forEach((key) => {
+        const field = obj[key];
+        let fieldCode = key + ': ';
+        if (field.constructor === Object) {
+            fieldCode += _getMatchObjCode(field);
+        } else {
+            fieldCode += field;
+        }
+        if (code.length > 1) {
+            code += ',';
+        }
+        code += fieldCode;
+    });
+
+    return code + '}';
+}
+
+function _compileMatch(obj, result, name, fieldName) {
+    if (obj.constructor !== Object) {
+        if (typeof obj !== 'string') {
+            // not a string, so it has to match exactly
+            result[fieldName] = obj;
+            return `${name} === ${obj}`;
+        }
+        if (obj[0] !== '/' && obj[obj.length - 1] !== '/') {
+            // not a regex, quote the string
+            result[fieldName] = `'${obj}'`;
+            return `${name} === '${obj}'`;
+        }
+        // it's a regex, we have to the test the arg
+        result[fieldName] = `${obj}.exec(${name})`;
+        return `${obj}.test(${name})`;
+    }
+
+    // this is an object, we need to split it into components
+    const subObj = fieldName ? {} : result;
+    const test = Object.keys(obj).map(
+        (key) => _compileMatch(obj[key], subObj, `${name}['${key}']`, key))
+    .join(' && ');
+    if (fieldName) {
+        result[fieldName] = subObj;
+    }
+    return test;
+}
+
 class Rule {
     constructor(name, spec) {
         this.name = name;
         this.spec = spec || {};
-        this.exec = [];
-        this.topic = '';
-        this.match = {
-            all: true
-        };
-        this.noop = false;
-        this._processRule();
+
+        this.topic = this.spec.topic;
+        if (!this.topic) {
+            throw new Error(`No topic specified for rule ${this.name}`);
+        }
+
+        this.exec = this._processExec(this.spec.exec);
+        this._match = this._processMatch(this.spec.match);
     }
 
     /**
@@ -24,7 +75,7 @@ class Rule {
      * @return true if no match is set for this rule or if the message matches
      */
     test(message) {
-        return this.match.all || this._matchTest(message);
+        return !this._match || !this._match.test || this._match.test(message);
     }
 
     /**
@@ -34,98 +85,44 @@ class Rule {
      * @return {Object} the object containing the expanded match portion of the rule
      */
     expand(message) {
-        return this._matchExpand(message);
+        return this._match && this._match.expand ? this._match.expand(message) : {};
     }
 
-    _compileMatch(obj, result, name, fieldName) {
-        if (obj.constructor !== Object) {
-            if (typeof obj !== 'string') {
-                // not a string, so it has to match exactly
-                result[fieldName] = obj;
-                return `${name} === ${obj}`;
-            }
-            if (obj[0] !== '/' && obj[obj.length - 1] !== '/') {
-                // not a regex, quote the string
-                result[fieldName] = `'${obj}'`;
-                return `${name} === '${obj}'`;
-            }
-            // it's a regex, we have to the test the arg
-            result[fieldName] = `${obj}.exec(${name})`;
-            return `${obj}.test(${name})`;
-        }
-
-        // this is an object, we need to split it into components
-        const subObj = fieldName ? {} : result;
-        const test = Object.keys(obj).map(
-            (key) => this._compileMatch(obj[key], subObj, `${name}['${key}']`, key))
-        .join(' && ');
-        if (fieldName) {
-            result[fieldName] = subObj;
-        }
-        return test;
-    }
-
-    _processMatch() {
-        // no particual match specified, so we
-        // should accept all events for this topic
-        if (!this.spec.match) {
+    _processMatch(match) {
+        if (!match) {
+            // No particular match specified, so we
+            // should accept all events for this topic
             return;
         }
-        this.match.all = false;
 
         const obj = {};
-        const test = this._compileMatch(this.spec.match, obj, 'message');
+        const test = _compileMatch(match, obj, 'message');
         try {
-            /* jslint evil: true  */
-            this._matchTest = new Function('message', 'return ' + test);
-            /* jslint evil: true  */
-            this._matchExpand = new Function('message', 'return ' +
-            this._getMatchObjCode(obj));
+            return {
+                /* jslint evil: true  */
+                test: new Function('message', 'return ' + test),
+                /* jslint evil: true  */
+                expand: new Function('message', 'return ' + _getMatchObjCode(obj))
+            };
         } catch (e) {
             throw new Error('Invalid match object given!');
         }
     }
 
-    _getMatchObjCode(obj) {
-        let code = '{';
-        if (obj.constructor !== Object) {
-            return '';
-        }
-        Object.keys(obj).forEach((key) => {
-            const field = obj[key];
-            let fieldCode = key + ': ';
-            if (field.constructor === Object) {
-                fieldCode += this._getMatchObjCode(field);
-            } else {
-                fieldCode += field;
-            }
-            if (code.length > 1) {
-                code += ',';
-            }
-            code += fieldCode;
-        });
-
-        return code + '}';
-    }
-
-    _processRule() {
-        // validate the rule spec
-        if (!this.spec.topic) {
-            throw new Error(`No topic specified for rule ${this.name}`);
-        }
-        if (!this.spec.exec) {
+    _processExec(exec) {
+        if (!exec) {
             // nothing to do, the rule is a no-op
             this.noop = true;
             return;
         }
-        if (!Array.isArray(this.spec.exec)) {
-            this.spec.exec = [this.spec.exec];
+
+        if (!Array.isArray(exec)) {
+            exec = [exec];
         }
 
-        const reqs = this.spec.exec;
         const templates = [];
-        for (let idx = 0; idx < reqs.length; idx++) {
-            const req = reqs[idx];
+        for (let idx = 0; idx < exec.length; idx++) {
+            const req = exec[idx];
             if (req.constructor !== Object || !req.uri) {
                 throw new Error(`In rule ${this.name}, request number ${idx}
                     must be an object and must have the "uri" property`);
@@ -134,22 +131,7 @@ class Rule {
             req.headers = req.headers || {};
             templates.push(new Template(req));
         }
-
-        this._processMatch();
-        this.topic = this.spec.topic;
-        this.exec = templates;
-    }
-
-    _matchTest() {
-        // NOTE: this method gets overriden by
-        // each Rule instance with a defined match object
-        return false;
-    }
-
-    _matchExpand() {
-        // NOTE: this method gets overriden by
-        // each Rule instance with a defined match object
-        return {};
+        return templates;
     }
 }
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,8 +1,48 @@
 'use strict';
 
-
+const stringify = require('json-stable-stringify');
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
+
+/**
+ * Creates a JS function that verifies property equality
+ *
+ * @param catchDefinition the condition in the format of 'catch' and 'return_if' stanza
+ * @returns {Function} a function that verifies the condition
+ */
+function _compileCatchFunction(catchDefinition) {
+    function createCondition(catchCond, option) {
+        if (catchCond === 'status') {
+            var opt = option.toString();
+            if (/^[0-9]+$/.test(opt)) {
+                return `(res["${catchCond}"] === ${opt})`;
+            }
+            if (/^[0-9x]+$/.test(opt)) {
+                return `Array.isArray(res["${catchCond}"].toString()
+                    .match(/^${opt.replace(/x/g, "\\d")}$/))`;
+            }
+            throw new Error(`Invalid catch condition ${opt}`);
+        } else {
+            return `(stringify(res["${catchCond}"]) === '${stringify(option)}')`;
+        }
+    }
+
+    var condition = [];
+    var code;
+    Object.keys(catchDefinition).forEach(function(catchCond) {
+        if (Array.isArray(catchDefinition[catchCond])) {
+            var orCondition = catchDefinition[catchCond].map(function(option) {
+                return createCondition(catchCond, option);
+            });
+            condition.push('(' + orCondition.join(' || ') + ')');
+        } else {
+            condition.push(createCondition(catchCond, catchDefinition[catchCond]));
+        }
+    });
+    code = `return (${condition.join(' && ')});`;
+    /* jslint evil: true */
+    return new Function('stringify', 'res', code).bind(null, stringify);
+}
 
 function _getMatchObjCode(obj) {
     let code = '{';
@@ -64,6 +104,13 @@ class Rule {
             throw new Error(`No topic specified for rule ${this.name}`);
         }
 
+        if (this.spec.retry_on) {
+            this.shouldRetry = _compileCatchFunction(this.spec.retry_on);
+        } else {
+            this.shouldRetry = function() {
+                return true;
+            };
+        }
         this.exec = this._processExec(this.spec.exec);
         this._match = this._processMatch(this.spec.match);
     }

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -7,36 +7,36 @@ const Template = HyperSwitch.Template;
 /**
  * Creates a JS function that verifies property equality
  *
- * @param catchDefinition the condition in the format of 'catch' and 'return_if' stanza
+ * @param retryDefinition the condition in the format of 'retry_on' stanza
  * @returns {Function} a function that verifies the condition
  */
-function _compileCatchFunction(catchDefinition) {
-    function createCondition(catchCond, option) {
-        if (catchCond === 'status') {
+function _compileRetryCondition(retryDefinition) {
+    function createCondition(retryCond, option) {
+        if (retryCond === 'status') {
             var opt = option.toString();
             if (/^[0-9]+$/.test(opt)) {
-                return `(res["${catchCond}"] === ${opt})`;
+                return `(res["${retryCond}"] === ${opt})`;
             }
             if (/^[0-9x]+$/.test(opt)) {
-                return `Array.isArray(res["${catchCond}"].toString()
+                return `Array.isArray(res["${retryCond}"].toString()
                     .match(/^${opt.replace(/x/g, "\\d")}$/))`;
             }
-            throw new Error(`Invalid catch condition ${opt}`);
+            throw new Error(`Invalid retry_on condition ${opt}`);
         } else {
-            return `(stringify(res["${catchCond}"]) === '${stringify(option)}')`;
+            return `(stringify(res["${retryCond}"]) === '${stringify(option)}')`;
         }
     }
 
     var condition = [];
     var code;
-    Object.keys(catchDefinition).forEach(function(catchCond) {
-        if (Array.isArray(catchDefinition[catchCond])) {
-            var orCondition = catchDefinition[catchCond].map(function(option) {
+    Object.keys(retryDefinition).forEach(function(catchCond) {
+        if (Array.isArray(retryDefinition[catchCond])) {
+            var orCondition = retryDefinition[catchCond].map(function(option) {
                 return createCondition(catchCond, option);
             });
             condition.push('(' + orCondition.join(' || ') + ')');
         } else {
-            condition.push(createCondition(catchCond, catchDefinition[catchCond]));
+            condition.push(createCondition(catchCond, retryDefinition[catchCond]));
         }
     });
     code = `return (${condition.join(' && ')});`;
@@ -103,14 +103,10 @@ class Rule {
         if (!this.topic) {
             throw new Error(`No topic specified for rule ${this.name}`);
         }
-
-        if (this.spec.retry_on) {
-            this.shouldRetry = _compileCatchFunction(this.spec.retry_on);
-        } else {
-            this.shouldRetry = function() {
-                return true;
-            };
-        }
+        this.spec.retry_on = this.spec.retry_on || {
+            status: [ '50x' ]
+        };
+        this.shouldRetry = _compileRetryCondition(this.spec.retry_on);
         this.exec = this._processExec(this.spec.exec);
         this._match = this._processMatch(this.spec.match);
     }

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -69,74 +69,77 @@ class RuleExecutor {
         }
     }
 
-    subscribe() {
-        const rule = this.rule;
-        const client = this.kafkaFactory.newClient();
-        return this.kafkaFactory.newConsumer(client, rule.topic, `change-prop-${rule.name}`)
-        .then((consumer) => {
-            this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
+    _getRetryTopicName() {
+        return this.rule.topic + '_' + this.rule.name + '.retry';
+    }
 
-            // Create a special queue for retries and continue and subscribe to it
-            const retryTopicName = rule.topic + '_' + rule.name + '.retry';
-            return this.kafkaFactory.newProducer(this.kafkaFactory.newClient())
-            .then((producer) => {
-                this.retryProducer = producer;
-                return producer.createTopicsAsync([ retryTopicName ], false);
-            })
-            .then(() => this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
+    /**
+     * Create a special queue for retries and subscribe to it.
+     *
+     * @private
+     */
+    _setUpRetryTopic() {
+        const retryTopicName = this._getRetryTopicName();
+
+        return this.kafkaFactory.newProducer(this.kafkaFactory.newClient())
+        .then((producer) => {
+            this.retryProducer = producer;
+            return producer.createTopicsAsync([ retryTopicName ], false);
+        })
+        .then(() => this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
                 retryTopicName, `change-prop-${retryTopicName}`))
-            .then((consumer) => {
-                this.retryConsumer = this._setConsumerLoggers(consumer, rule.name, retryTopicName);
-                this.retryConsumer.on('message', (msg) => {
-                    const message = this._safeParse(msg.value);
-                    if (!message) {
-                        // Don't retry if we can't parse an event, just log.
-                        return;
-                    }
-
-                    if (message.retryCount >= (this.rule.spec.retry_limit || 3)) {
-                        this.log(`error/${rule.name}`, {
-                            message: 'Retry count exceeded',
-                            event: message
-                        });
-                    } else {
-                        return this._exec(message.value)
-                        .then(() => this.retryConsumer.commitAsync())
-                        .catch(() => P.delay(this.rule.spec.retry_delay || 500)
-                        .then(() => {
-                            message.retryCount = message.retryCount + 1;
-                            return this.retryProducer.sendAsync([{
-                                topic: retryTopicName,
-                                messages: [ JSON.stringify(message) ]
-                            }])
-                            .then(() => this.retryConsumer.commitAsync());
-                        }));
-                    }
-                });
-            })
-            .then(() => this.consumer.on('message', (msg) => {
-                const msgObj = this._safeParse(msg.value);
-                if (!msgObj) {
+        .then((consumer) => {
+            this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
+            this.retryConsumer.on('message', (msg) => {
+                const message = this._safeParse(msg.value);
+                if (!message) {
                     // Don't retry if we can't parse an event, just log.
                     return;
                 }
 
-                return this._exec(msgObj)
-                .then(() => this.consumer.commitAsync())
-                .catch(() =>
-                    P.delay(this.rule.spec.retry_delay || 500)
-                    .then(() =>
-                        this.retryProducer.sendAsync([{
-                            topic: retryTopicName,
-                            messages: [JSON.stringify({
-                                retryCount: 1,
-                                value: msgObj
-                            })]
-                        }])
-                        .then(() => this.consumer.commitAsync())
-                    )
-                );
-            }));
+                if (message.retryCount >= (this.rule.spec.retry_limit || 3)) {
+                    this.log(`error/${this.rule.name}`, {
+                        message: 'Retry count exceeded',
+                        event: message
+                    });
+                } else {
+                    return this._exec(message.value).then(() => this.retryConsumer.commitAsync())
+                    .catch(() => {
+                        message.retryCount = message.retryCount + 1;
+                        return this._retry(message, this.retryConsumer);
+                    });
+                }
+            });
+        });
+    }
+
+    _retry(retryMessage, messageOriginConsumer) {
+        return P.delay(this.rule.spec.retry_delay || 500)
+        .then(() => this.retryProducer.sendAsync([{
+            topic: this._getRetryTopicName(),
+            messages: [ JSON.stringify(retryMessage) ]
+        }]))
+        .then(() => messageOriginConsumer.commitAsync());
+    }
+
+    subscribe() {
+        const rule = this.rule;
+        const client = this.kafkaFactory.newClient();
+        return this._setUpRetryTopic()
+        .then(() => {
+            return this.kafkaFactory.newConsumer(client, rule.topic, `change-prop-${rule.name}`)
+            .then((consumer) => {
+                this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
+                this.consumer.on('message', (msg) => {
+                    const msgObj = this._safeParse(msg.value);
+                    if (!msgObj) {
+                        // Don't retry if we can't parse an event, just log.
+                        return;
+                    }
+                    return this._exec(msgObj).then(() => this.consumer.commitAsync())
+                    .catch(() => this._retry({ retryCount: 1, value: msgObj }, this.consumer));
+                });
+            });
         });
     }
 }

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -78,7 +78,7 @@ class RuleExecutor {
     }
 
     _isLimitExceeded(message) {
-        if (message.retry_count > (this.rule.spec.retry_limit || DEFAULT_RETRY_LIMIT)) {
+        if (message.retries_left <= 0) {
             this.log(`error/${this.rule.name}`, {
                 message: 'Retry count exceeded',
                 event: message
@@ -123,13 +123,22 @@ class RuleExecutor {
 
                     return this._exec(message.original_event)
                     .catch((e) => {
-                        message.retry_count = message.retry_count + 1;
-                        return this._retry(message);
+                        if (this._shouldRetry(e)) {
+                            return this._retry(this._constructRetryMessage(message.original_event,
+                                e, message.retries_left - 1));
+                        }
                     });
                 })
                 .then(() => this.retryConsumer.commitAsync());
             });
         });
+    }
+
+    _shouldRetry(errorRes) {
+        if (this.rule.spec.retry_on) {
+            return this.rule.spec.retry_on.indexOf(errorRes.status) !== -1;
+        }
+        return true;
     }
 
     _retry(retryMessage) {
@@ -144,8 +153,19 @@ class RuleExecutor {
         return 'change-prop#' + this.rule.name;
     }
 
-    _constructRetryMessage(event) {
+    _constructRetryMessage(event, errorRes, retriesLeft) {
         const now = new Date();
+        const error = {
+            status: errorRes.status
+        };
+        if (errorRes.body) {
+            error.type = errorRes.body.type;
+            error.method = errorRes.body.method;
+            error.uri = errorRes.body.uri;
+            error.title = errorRes.body.title;
+            error.detail = errorRes.body.detail;
+        }
+
         return {
             meta: {
                 topic: this._retryTopicName(),
@@ -157,8 +177,10 @@ class RuleExecutor {
                 domain: event.meta.domain
             },
             consumer_id: this._consumerId(),
-            retry_count: 1,
-            original_event: event
+            retries_left: retriesLeft === undefined ?
+                (this.rule.spec.retry_limit || DEFAULT_RETRY_LIMIT) : retriesLeft,
+            original_event: event,
+            error: error
         };
     }
 
@@ -178,7 +200,11 @@ class RuleExecutor {
                             return;
                         }
                         return this._exec(msgObj)
-                        .catch(() => this._retry(this._constructRetryMessage(msgObj)));
+                        .catch((e) => {
+                            if (this._shouldRetry(e)) {
+                                return this._retry(this._constructRetryMessage(msgObj, e));
+                            }
+                        });
                     })
                     .then(() => this.consumer.commitAsync());
                 });

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -111,7 +111,7 @@ class RuleExecutor {
                         return;
                     }
 
-                    if (message.consumer_id !== this._consumerId()) {
+                    if (message.emitter_id !== this._consumerId()) {
                         // Not our business, don't care
                         return;
                     }
@@ -123,22 +123,16 @@ class RuleExecutor {
 
                     return this._exec(message.original_event)
                     .catch((e) => {
-                        if (this._shouldRetry(e)) {
-                            return this._retry(this._constructRetryMessage(message.original_event,
-                                e, message.retries_left - 1));
+                        const retryMessage = this._constructRetryMessage(message.original_event,
+                            e, message.retries_left - 1);
+                        if (this.rule.shouldRetry(e) && !this._isLimitExceeded(retryMessage)) {
+                            return this._retry(retryMessage);
                         }
                     });
                 })
                 .then(() => this.retryConsumer.commitAsync());
             });
         });
-    }
-
-    _shouldRetry(errorRes) {
-        if (this.rule.spec.retry_on) {
-            return this.rule.spec.retry_on.indexOf(errorRes.status) !== -1;
-        }
-        return true;
     }
 
     _retry(retryMessage) {
@@ -165,7 +159,7 @@ class RuleExecutor {
                 dt: now.toISOString(),
                 domain: event.meta.domain
             },
-            consumer_id: this._consumerId(),
+            emitter_id: this._consumerId(),
             retries_left: retriesLeft === undefined ?
                 (this.rule.spec.retry_limit || DEFAULT_RETRY_LIMIT) : retriesLeft,
             original_event: event,
@@ -190,7 +184,7 @@ class RuleExecutor {
                         }
                         return this._exec(msgObj)
                         .catch((e) => {
-                            if (this._shouldRetry(e)) {
+                            if (this.rule.shouldRetry(e)) {
                                 return this._retry(this._constructRetryMessage(msgObj, e));
                             }
                         });

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -1,6 +1,10 @@
 "use strict";
 
 const P = require('bluebird');
+const uuid = require('cassandra-uuid').TimeUuid;
+
+const DEFAULT_RETRY_DELAY = 500;
+const DEFAULT_RETRY_LIMIT = 3;
 
 /**
  * A rule executor managing matching and execution of a single rule
@@ -69,25 +73,34 @@ class RuleExecutor {
         }
     }
 
-    _getRetryTopicName() {
-        return this.rule.topic + '_' + this.rule.name + '.retry';
+    _retryTopicName() {
+        return this.rule.topic + '.retry';
     }
 
+    _isLimitExceeded(message) {
+        if (message.retry_count > (this.rule.spec.retry_limit || DEFAULT_RETRY_LIMIT)) {
+            this.log(`error/${this.rule.name}`, {
+                message: 'Retry count exceeded',
+                event: message
+            });
+            return true;
+        }
+        return false;
+    }
     /**
-     * Create a special queue for retries and subscribe to it.
+     * Set's up a consumer and a producer for a retry queue
      *
      * @private
      */
     _setUpRetryTopic() {
-        const retryTopicName = this._getRetryTopicName();
+        const retryTopicName = this._retryTopicName();
 
         return this.kafkaFactory.newProducer(this.kafkaFactory.newClient())
         .then((producer) => {
             this.retryProducer = producer;
-            return producer.createTopicsAsync([ retryTopicName ], false);
+            return this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
+                retryTopicName, `change-prop-${retryTopicName}-${this.rule.name}`);
         })
-        .then(() => this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
-                retryTopicName, `change-prop-${retryTopicName}`))
         .then((consumer) => {
             this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
             this.retryConsumer.on('message', (msg) => {
@@ -98,18 +111,21 @@ class RuleExecutor {
                         return;
                     }
 
-                    if (message.retryCount >= (this.rule.spec.retry_limit || 3)) {
-                        this.log(`error/${this.rule.name}`, {
-                            message: 'Retry count exceeded',
-                            event: message
-                        });
-                    } else {
-                        return this._exec(message.value)
-                        .catch(() => {
-                            message.retryCount = message.retryCount + 1;
-                            return this._retry(message);
-                        });
+                    if (message.consumer_id !== this._consumerId()) {
+                        // Not our business, don't care
+                        return;
                     }
+
+                    if (this._isLimitExceeded(message)) {
+                        // We've don our best, give up
+                        return;
+                    }
+
+                    return this._exec(message.original_event)
+                    .catch((e) => {
+                        message.retry_count = message.retry_count + 1;
+                        return this._retry(message);
+                    });
                 })
                 .then(() => this.retryConsumer.commitAsync());
             });
@@ -117,11 +133,33 @@ class RuleExecutor {
     }
 
     _retry(retryMessage) {
-        return P.delay(this.rule.spec.retry_delay || 500)
+        return P.delay(this.rule.spec.retry_delay || DEFAULT_RETRY_DELAY)
         .then(() => this.retryProducer.sendAsync([{
-            topic: this._getRetryTopicName(),
+            topic: this._retryTopicName(),
             messages: [ JSON.stringify(retryMessage) ]
         }]));
+    }
+
+    _consumerId() {
+        return 'change-prop#' + this.rule.name;
+    }
+
+    _constructRetryMessage(event) {
+        const now = new Date();
+        return {
+            meta: {
+                topic: this._retryTopicName(),
+                schema_uri: 'retry/1',
+                uri: event.meta.uri,
+                request_id: event.meta.request_id,
+                id: uuid.fromDate(now),
+                dt: now.toISOString(),
+                domain: event.meta.domain
+            },
+            consumer_id: this._consumerId(),
+            retry_count: 1,
+            original_event: event
+        };
     }
 
     subscribe() {
@@ -140,7 +178,7 @@ class RuleExecutor {
                             return;
                         }
                         return this._exec(msgObj)
-                        .catch(() => this._retry({ retryCount: 1, value: msgObj }));
+                        .catch(() => this._retry(this._constructRetryMessage(msgObj)));
                     })
                     .then(() => this.consumer.commitAsync());
                 });

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -22,58 +22,123 @@ class RuleExecutor {
         this.log = log;
     }
 
+    _setConsumerLoggers(consumer, ruleName, topic) {
+        consumer.on('topics_changed', (topicList) => {
+            // only one topic can be subscribed to by this client
+            if (topicList && topicList.length) {
+                this.log(`info/subscription/${ruleName}`, {
+                    rule: { name: ruleName, topic },
+                    msg: `Listening to ${topicList[0]}`
+                });
+            } else {
+                this.log(`info/subscription/${ruleName}`, {
+                    rule: { name: ruleName, topic },
+                    msg: `Lost ownership of ${topic}`
+                });
+            }
+        });
+        consumer.on('error', (err) => this.log(`warn/error/${ruleName}`, {
+            err,
+            rule: { name: ruleName, topic }
+        }));
+        return consumer;
+    }
+
     _exec(event) {
         const rule = this.rule;
-        const expander = {
-            message: event,
-            match: null
-        };
-
         if (!rule.test(event)) {
             // no match, drop the message
             this.log(`debug/${rule.name}`, { msg: 'Dropping event message', event: event });
-            return;
+            return P.resolve();
         }
 
         this.log(`trace/${rule.name}`, { msg: 'Event message received', event: event });
-        expander.match = rule.expand(event);
 
+        const expander = {
+            message: event,
+            match: rule.expand(event)
+        };
         return P.each(rule.exec, (tpl) => this.hyper.request(tpl.expand(expander)));
+    }
+
+    _safeParse(message) {
+        try {
+            return JSON.parse(message);
+        } catch (e) {
+            this.log(`error/${this.rule.name}`, e);
+        }
     }
 
     subscribe() {
         const rule = this.rule;
-        const logRule = { name: rule.name, topic: rule.topic };
         const client = this.kafkaFactory.newClient();
         return this.kafkaFactory.newConsumer(client, rule.topic, `change-prop-${rule.name}`)
         .then((consumer) => {
-            this.consumer = consumer;
-            consumer.on('message', (message) =>
-                P.try(() =>
-                    this._exec(JSON.parse(message.value)))
-                .catch((err) =>
-                    this.log(`info/${rule.name}`, err)));
-            consumer.on('topics_changed', (topicList) => {
-                // only one topic can be subscribed to by this client
-                if (topicList && topicList.length) {
-                    this.log(`info/subscription/${rule.name}`, {
-                        rule: logRule,
-                        msg: `Listening to ${topicList[0]}`
-                    });
-                } else {
-                    this.log(`info/subscription/${rule.name}`, {
-                        rule: logRule,
-                        msg: `Lost ownership of ${rule.topic}`
-                    });
+            this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
+
+            // Create a special queue for retries and continue and subscribe to it
+            const retryTopicName = rule.topic + '_' + rule.name + '.retry';
+            return this.kafkaFactory.newProducer(this.kafkaFactory.newClient())
+            .then((producer) => {
+                this.retryProducer = producer;
+                return producer.createTopicsAsync([ retryTopicName ], false);
+            })
+            .then(() => this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
+                retryTopicName, `change-prop-${retryTopicName}`))
+            .then((consumer) => {
+                this.retryConsumer = this._setConsumerLoggers(consumer, rule.name, retryTopicName);
+                this.retryConsumer.on('message', (msg) => {
+                    const message = this._safeParse(msg.value);
+                    if (!message) {
+                        // Don't retry if we can't parse an event, just log.
+                        return;
+                    }
+
+                    if (message.retryCount >= (this.rule.spec.retry_limit || 3)) {
+                        this.log(`error/${rule.name}`, {
+                            message: 'Retry count exceeded',
+                            event: message
+                        });
+                    } else {
+                        return this._exec(message.value)
+                        .then(() => this.retryConsumer.commitAsync())
+                        .catch(() => P.delay(this.rule.spec.retry_delay || 500)
+                        .then(() => {
+                            message.retryCount = message.retryCount + 1;
+                            return this.retryProducer.sendAsync([{
+                                topic: retryTopicName,
+                                messages: [ JSON.stringify(message) ]
+                            }])
+                            .then(() => this.retryConsumer.commitAsync());
+                        }));
+                    }
+                });
+            })
+            .then(() => this.consumer.on('message', (msg) => {
+                const msgObj = this._safeParse(msg.value);
+                if (!msgObj) {
+                    // Don't retry if we can't parse an event, just log.
+                    return;
                 }
-            });
-            consumer.on('error', (err) => this.log(`warn/error/${rule.name}`, {
-                err,
-                rule: logRule
+
+                return this._exec(msgObj)
+                .then(() => this.consumer.commitAsync())
+                .catch(() =>
+                    P.delay(this.rule.spec.retry_delay || 500)
+                    .then(() =>
+                        this.retryProducer.sendAsync([{
+                            topic: retryTopicName,
+                            messages: [JSON.stringify({
+                                retryCount: 1,
+                                value: msgObj
+                            })]
+                        }])
+                        .then(() => this.consumer.commitAsync())
+                    )
+                );
             }));
         });
     }
-
 }
 
 module.exports = RuleExecutor;

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -91,35 +91,37 @@ class RuleExecutor {
         .then((consumer) => {
             this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
             this.retryConsumer.on('message', (msg) => {
-                const message = this._safeParse(msg.value);
-                if (!message) {
-                    // Don't retry if we can't parse an event, just log.
-                    return;
-                }
+                return P.try(() => {
+                    const message = this._safeParse(msg.value);
+                    if (!message) {
+                        // Don't retry if we can't parse an event, just log.
+                        return;
+                    }
 
-                if (message.retryCount >= (this.rule.spec.retry_limit || 3)) {
-                    this.log(`error/${this.rule.name}`, {
-                        message: 'Retry count exceeded',
-                        event: message
-                    });
-                } else {
-                    return this._exec(message.value).then(() => this.retryConsumer.commitAsync())
-                    .catch(() => {
-                        message.retryCount = message.retryCount + 1;
-                        return this._retry(message, this.retryConsumer);
-                    });
-                }
+                    if (message.retryCount >= (this.rule.spec.retry_limit || 3)) {
+                        this.log(`error/${this.rule.name}`, {
+                            message: 'Retry count exceeded',
+                            event: message
+                        });
+                    } else {
+                        return this._exec(message.value)
+                        .catch(() => {
+                            message.retryCount = message.retryCount + 1;
+                            return this._retry(message);
+                        });
+                    }
+                })
+                .then(() => this.retryConsumer.commitAsync());
             });
         });
     }
 
-    _retry(retryMessage, messageOriginConsumer) {
+    _retry(retryMessage) {
         return P.delay(this.rule.spec.retry_delay || 500)
         .then(() => this.retryProducer.sendAsync([{
             topic: this._getRetryTopicName(),
             messages: [ JSON.stringify(retryMessage) ]
-        }]))
-        .then(() => messageOriginConsumer.commitAsync());
+        }]));
     }
 
     subscribe() {
@@ -131,13 +133,16 @@ class RuleExecutor {
             .then((consumer) => {
                 this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
                 this.consumer.on('message', (msg) => {
-                    const msgObj = this._safeParse(msg.value);
-                    if (!msgObj) {
-                        // Don't retry if we can't parse an event, just log.
-                        return;
-                    }
-                    return this._exec(msgObj).then(() => this.consumer.commitAsync())
-                    .catch(() => this._retry({ retryCount: 1, value: msgObj }, this.consumer));
+                    return P.try(() => {
+                        const msgObj = this._safeParse(msg.value);
+                        if (!msgObj) {
+                            // Don't retry if we can't parse an event, just log.
+                            return;
+                        }
+                        return this._exec(msgObj)
+                        .catch(() => this._retry({ retryCount: 1, value: msgObj }));
+                    })
+                    .then(() => this.consumer.commitAsync());
                 });
             });
         });

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -74,7 +74,7 @@ class RuleExecutor {
     }
 
     _retryTopicName() {
-        return this.rule.topic + '.retry';
+        return 'change-prop.retry.' + this.rule.topic;
     }
 
     _isLimitExceeded(message) {
@@ -155,17 +155,6 @@ class RuleExecutor {
 
     _constructRetryMessage(event, errorRes, retriesLeft) {
         const now = new Date();
-        const error = {
-            status: errorRes.status
-        };
-        if (errorRes.body) {
-            error.type = errorRes.body.type;
-            error.method = errorRes.body.method;
-            error.uri = errorRes.body.uri;
-            error.title = errorRes.body.title;
-            error.detail = errorRes.body.detail;
-        }
-
         return {
             meta: {
                 topic: this._retryTopicName(),
@@ -180,7 +169,7 @@ class RuleExecutor {
             retries_left: retriesLeft === undefined ?
                 (this.rule.spec.retry_limit || DEFAULT_RETRY_LIMIT) : retriesLeft,
             original_event: event,
-            error: error
+            reason: errorRes && errorRes.body && errorRes.body.title
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "cassandra-uuid": "^0.0.2",
     "hyperswitch": "^0.3.2",
     "service-runner": "^1.1.7",
-    "wmf-kafka-node": "^0.1.0"
+    "wmf-kafka-node": "^0.1.0",
+    "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master"
   },
   "devDependencies": {
     "extend": "^3.0.0",
@@ -48,7 +49,9 @@
     "mocha-lcov-reporter": "^1.2.0",
     "coveralls": "^2.11.6",
     "js-yaml": "^3.5.2",
-    "nock": "^8.0.0"
+    "nock": "^8.0.0",
+    "preq": "^0.4.9",
+    "ajv": "^4.0.3"
   },
   "deploy": {
     "node": "4.3.0",

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -111,6 +111,27 @@ describe('Basic rule management', function() {
         .finally(function() { nock.cleanAll(); });
     });
 
+    it('Should not retry if retry_on not matched', function() {
+        var service = nock('http://mock.com', {
+            reqheaders: {
+                test_header_name: 'test_header_value',
+                'content-type': 'application/json'
+            }
+        })
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test'
+        }).reply(404, {});
+
+        return producer.sendAsync([{
+            topic: 'test_topic_simple_test_rule',
+            messages: [ JSON.stringify(eventWithMessage('test')) ]
+        }])
+        .delay(300)
+        .then(function() { service.done(); })
+        .finally(function() { nock.cleanAll(); });
+    });
+
     it('Should not crash with unparsable JSON', function() {
         var service = nock('http://mock.com', {
             reqheaders: {

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -19,7 +19,7 @@ describe('Basic rule management', function() {
             producer = newProducer;
             return producer.createTopicsAsync([
                 'test_topic_simple_test_rule',
-                'test_topic_simple_test_rule.retry'
+                'change-prop.retry.test_topic_simple_test_rule'
             ], false)
         })
         .then(function() {


### PR DESCRIPTION
1. Retry queues to retry specific rules. For every rule a retry topic is created. In case rule execution results in an error we wrap an original event in an envelope, add a retryCount property and post the event to a special topic. Listener of this topic checks whether retryCount was not exceeded and tries to execute a rule one more time.
2. Explicit kafka commit - only commit if the event handling succeeded or the retry was posted. Switched off `autoCommit` for consumers, so now we commit the offset on after either a rule was successfully executed, or an event was posted in the retry topic.
3. Refactor Role to make most of the private functions actually module-private.

cc @wikimedia/services 