### PR TITLE
Support producing messages to topics from a rule executor

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -10,7 +10,7 @@ services:
       spec:
         title: The Change Propagation root
         paths:
-          /{domain:a}/sys/queue:
+          /sys/queue:
             x-modules:
               - path: sys/kafka.js
                 options:
@@ -35,3 +35,13 @@ services:
                         body:
                           test_field_name: test_field_value
                           derived_field: '{{message.message}}'
+
+                    kafka_producing_rule:
+                      topic: test_topic_kafka_producing_rule
+                      exec:
+                        method: 'post'
+                        uri: '/sys/queue/produce'
+                        body:
+                          topic: '{{message.produce_to_topic}}'
+                          messages:
+                            - message: 'Created an event'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -44,4 +44,4 @@ services:
                         body:
                           topic: '{{message.produce_to_topic}}'
                           messages:
-                            - message: 'Created an event'
+                            - message: 'test'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -40,8 +40,11 @@ services:
                       topic: test_topic_kafka_producing_rule
                       exec:
                         method: 'post'
-                        uri: '/sys/queue/produce'
+                        uri: '/sys/queue/events'
                         body:
-                          topic: '{{message.produce_to_topic}}'
-                          messages:
-                            - message: 'test'
+                          - meta:
+                              topic: '{{message.produce_to_topic}}'
+                            message: 'test'
+                          - meta:
+                              topic: '{{message.produce_to_topic}}'
+                            message: 'test'

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -13,7 +13,7 @@ const Template = HyperSwitch.Template;
 function _compileRetryCondition(retryDefinition) {
     function createCondition(retryCond, option) {
         if (retryCond === 'status') {
-            var opt = option.toString();
+            const opt = option.toString();
             if (/^[0-9]+$/.test(opt)) {
                 return `(res["${retryCond}"] === ${opt})`;
             }
@@ -27,19 +27,17 @@ function _compileRetryCondition(retryDefinition) {
         }
     }
 
-    var condition = [];
-    var code;
-    Object.keys(retryDefinition).forEach(function(catchCond) {
+    const condition = [];
+    Object.keys(retryDefinition).forEach((catchCond) => {
         if (Array.isArray(retryDefinition[catchCond])) {
-            var orCondition = retryDefinition[catchCond].map(function(option) {
-                return createCondition(catchCond, option);
-            });
+            const orCondition = retryDefinition[catchCond].map((option) =>
+                createCondition(catchCond, option));
             condition.push('(' + orCondition.join(' || ') + ')');
         } else {
             condition.push(createCondition(catchCond, retryDefinition[catchCond]));
         }
     });
-    code = `return (${condition.join(' && ')});`;
+    const code = `return (${condition.join(' && ')});`;
     /* jslint evil: true */
     return new Function('stringify', 'res', code).bind(null, stringify);
 }

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -9,7 +9,9 @@ const Ajv = require('ajv');
 const assert = require('assert');
 const yaml = require('js-yaml');
 
-describe('Basic rule management', () => {
+describe('Basic rule management', function() {
+    this.timeout(1000);
+
     const changeProp = new ChangeProp('config.test.yaml');
     const kafkaFactory = new KafkaFactory({
         uri: 'localhost:2181/', // TODO: find out from the config
@@ -18,14 +20,18 @@ describe('Basic rule management', () => {
     let producer;
     let retrySchema;
 
-    before(() => {
+    before(function() {
+        // Setting up might tike some tome, so disable the timeout
+        this.timeout(0);
+
         return kafkaFactory.newProducer(kafkaFactory.newClient())
         .then((newProducer) => {
             producer = newProducer;
             return producer.createTopicsAsync([
                 'test_topic_simple_test_rule',
                 'change-prop.retry.test_topic_simple_test_rule',
-                'test_topic_kafka_producing_rule'
+                'test_topic_kafka_producing_rule',
+                'change-prop.retry.test_topic_kafka_producing_rule'
             ], false)
         })
         .then(() => changeProp.start())
@@ -71,29 +77,6 @@ describe('Basic rule management', () => {
         .delay(100)
         .then(() => service.done())
         .finally(() => nock.cleanAll());
-    });
-
-    it('Should support producing to topics on exec', function() {
-        var service = nock('http://mock.com', {
-            reqheaders: {
-                test_header_name: 'test_header_value',
-                'content-type': 'application/json'
-            }
-        })
-        .post('/', {
-            'test_field_name': 'test_field_value',
-            'derived_field': 'Created an event'
-        }).reply({});
-
-        return producer.sendAsync([{
-            topic: 'test_topic_kafka_producing_rule',
-            messages: [ JSON.stringify({
-                produce_to_topic: 'test_topic_simple_test_rule'
-            }) ]
-        }])
-        .delay(100)
-        .then(function() { service.done(); })
-        .finally(function() { nock.cleanAll(); });
     });
 
     it('Should retry simple executor', () => {
@@ -207,6 +190,29 @@ describe('Basic rule management', () => {
         .delay(100)
         .then(() => service.done())
         .finally(() => nock.cleanAll());
+    });
+
+    it('Should support producing to topics on exec', function() {
+        var service = nock('http://mock.com', {
+            reqheaders: {
+                test_header_name: 'test_header_value',
+                'content-type': 'application/json'
+            }
+        })
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test'
+        }).reply({});
+
+        return producer.sendAsync([{
+            topic: 'test_topic_kafka_producing_rule',
+            messages: [ JSON.stringify({
+                produce_to_topic: 'test_topic_simple_test_rule'
+            }) ]
+        }])
+        .delay(100)
+        .then(function() { service.done(); })
+        .finally(function() { nock.cleanAll(); });
     });
 
     after(() => changeProp.stop());

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -24,7 +24,8 @@ describe('Basic rule management', () => {
             producer = newProducer;
             return producer.createTopicsAsync([
                 'test_topic_simple_test_rule',
-                'change-prop.retry.test_topic_simple_test_rule'
+                'change-prop.retry.test_topic_simple_test_rule',
+                'test_topic_kafka_producing_rule'
             ], false)
         })
         .then(() => changeProp.start())
@@ -70,6 +71,29 @@ describe('Basic rule management', () => {
         .delay(100)
         .then(() => service.done())
         .finally(() => nock.cleanAll());
+    });
+
+    it('Should support producing to topics on exec', function() {
+        var service = nock('http://mock.com', {
+            reqheaders: {
+                test_header_name: 'test_header_value',
+                'content-type': 'application/json'
+            }
+        })
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'Created an event'
+        }).reply({});
+
+        return producer.sendAsync([{
+            topic: 'test_topic_kafka_producing_rule',
+            messages: [ JSON.stringify({
+                produce_to_topic: 'test_topic_simple_test_rule'
+            }) ]
+        }])
+        .delay(100)
+        .then(function() { service.done(); })
+        .finally(function() { nock.cleanAll(); });
     });
 
     it('Should retry simple executor', () => {

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -202,7 +202,7 @@ describe('Basic rule management', function() {
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).reply({});
+        }).times(2).reply({});
 
         return producer.sendAsync([{
             topic: 'test_topic_kafka_producing_rule',

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,1 @@
 --recursive
---no-timeouts


### PR DESCRIPTION
See https://phabricator.wikimedia.org/T133221 for some background. 

I'm not 100% sure we really want to allow this or not (should all the event production go through the eventlogging-service, or would we allow doing shortcuts like this?)

cc @wikimedia/services 