### PR TITLE
Set up config parameter to parameterize production and consumption DC

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,4 +43,6 @@ services:
               - path: sys/kafka.js
                 options:
                   uri: 127.0.0.1:2181
+                  consume_dc: default
+                  produce_dc: default
                   templates: {}

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -15,9 +15,11 @@ services:
               - path: sys/kafka.js
                 options:
                   uri: 127.0.0.1:2181
+                  consume_dc: test_dc
+                  produce_dc: test_dc
                   templates:
                     simple_test_rule:
-                      topic: test_topic_simple_test_rule
+                      topic: simple_test_rule
                       retry_limit: 2
                       retry_delay: 10
                       retry_on:
@@ -37,7 +39,7 @@ services:
                           derived_field: '{{message.message}}'
 
                     kafka_producing_rule:
-                      topic: test_topic_kafka_producing_rule
+                      topic: kafka_producing_rule
                       exec:
                         method: 'post'
                         uri: '/sys/queue/events'

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -12,8 +12,10 @@ class KafkaFactory {
      * @param {Object} kafkaConf Kafka connection configuration
      * @param {string} kafkaConf.uri Zookeper URI with host and port
      * @param {string} kafkaConf.clientId Client identification string
-     * @param {string} kafkaConf.consume_dc DC name to consume from
-     * @param {string} kafkaConf.produce_dc DC name to produce to
+     * @param {string} [kafkaConf.consume_dc] DC name to consume from
+     * @param {string} [kafkaConf.produce_dc] DC name to produce to
+     * @param {string} [kafkaConf.dc_name] DC name to use both for
+     *                                     production and consumption
      * @constructor
      */
     constructor(kafkaConf) {
@@ -21,14 +23,6 @@ class KafkaFactory {
 
         if (!this.kafkaConf.uri) {
             throw new Error('uri config parameter is required by kafka config');
-        }
-
-        if (!this.kafkaConf.consume_dc) {
-            throw new Error('consume_dc config parameter is required by kafka config');
-        }
-
-        if (!this.kafkaConf.produce_dc) {
-            throw new Error('produce_dc config parameter is required by kafka config');
         }
     }
 
@@ -69,10 +63,11 @@ class KafkaFactory {
      * @returns {Promise} a promise that's resolved when a consumer is ready
      */
     newConsumer(client, topic, groupId, offset) {
+        const prefixedTopic = this.consumeDC ? `${this.consumeDC}.${topic}` : topic;
         return new P((resolve, reject) => {
             const consumer = new kafka.HighLevelConsumer(client,
                 [{
-                    topic: `${this.consumeDC}.${topic}`,
+                    topic: prefixedTopic,
                     offset: offset
                 }],
                 {
@@ -90,7 +85,7 @@ class KafkaFactory {
      * @returns {string}
      */
     get consumeDC() {
-        return this.kafkaConf.consume_dc;
+        return this.kafkaConf.dc_name || this.kafkaConf.consume_dc;
     }
 
     /**
@@ -99,7 +94,7 @@ class KafkaFactory {
      * @returns {string}
      */
     get produceDC() {
-        return this.kafkaConf.produce_dc;
+        return this.kafkaConf.dc_name || this.kafkaConf.produce_dc;
     }
 }
 

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -12,10 +12,24 @@ class KafkaFactory {
      * @param {Object} kafkaConf Kafka connection configuration
      * @param {string} kafkaConf.uri Zookeper URI with host and port
      * @param {string} kafkaConf.clientId Client identification string
+     * @param {string} kafkaConf.consume_dc DC name to consume from
+     * @param {string} kafkaConf.produce_dc DC name to produce to
      * @constructor
      */
     constructor(kafkaConf) {
         this.kafkaConf = kafkaConf;
+
+        if (!this.kafkaConf.uri) {
+            throw new Error('uri config parameter is required by kafka config');
+        }
+
+        if (!this.kafkaConf.consume_dc) {
+            throw new Error('consume_dc config parameter is required by kafka config');
+        }
+
+        if (!this.kafkaConf.produce_dc) {
+            throw new Error('produce_dc config parameter is required by kafka config');
+        }
     }
 
     /**
@@ -56,13 +70,36 @@ class KafkaFactory {
      */
     newConsumer(client, topic, groupId, offset) {
         return new P((resolve, reject) => {
-            const consumer = new kafka.HighLevelConsumer(client, [{ topic, offset }], {
-                groupId,
-                autoCommit: false
-            });
+            const consumer = new kafka.HighLevelConsumer(client,
+                [{
+                    topic: `${this.consumeDC}.${topic}`,
+                    offset: offset
+                }],
+                {
+                    groupId,
+                    autoCommit: false
+                });
             consumer.once('error', reject);
             consumer.once('rebalanced', () => resolve(P.promisifyAll(consumer)));
         });
+    }
+
+    /**
+     * Returns a DC name to consume from
+     *
+     * @returns {string}
+     */
+    get consumeDC() {
+        return this.kafkaConf.consume_dc;
+    }
+
+    /**
+     * Returns a DC name to produce to
+     *
+     * @returns {string}
+     */
+    get produceDC() {
+        return this.kafkaConf.produce_dc;
     }
 }
 

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -63,11 +63,10 @@ class KafkaFactory {
      * @returns {Promise} a promise that's resolved when a consumer is ready
      */
     newConsumer(client, topic, groupId, offset) {
-        const prefixedTopic = this.consumeDC ? `${this.consumeDC}.${topic}` : topic;
         return new P((resolve, reject) => {
             const consumer = new kafka.HighLevelConsumer(client,
                 [{
-                    topic: prefixedTopic,
+                    topic: `${this.consumeDC}.${topic}`,
                     offset: offset
                 }],
                 {
@@ -85,7 +84,7 @@ class KafkaFactory {
      * @returns {string}
      */
     get consumeDC() {
-        return this.kafkaConf.dc_name || this.kafkaConf.consume_dc;
+        return this.kafkaConf.dc_name || this.kafkaConf.consume_dc || 'datacenter1';
     }
 
     /**
@@ -94,7 +93,7 @@ class KafkaFactory {
      * @returns {string}
      */
     get produceDC() {
-        return this.kafkaConf.dc_name || this.kafkaConf.produce_dc;
+        return this.kafkaConf.dc_name || this.kafkaConf.produce_dc || 'datacenter1';
     }
 }
 

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -88,19 +88,16 @@ class RuleExecutor {
         return false;
     }
     /**
-     * Set's up a consumer and a producer for a retry queue
+     * Set's up a consumer a retry queue
      *
      * @private
      */
     _setUpRetryTopic() {
         const retryTopicName = this._retryTopicName();
 
-        return this.kafkaFactory.newProducer(this.kafkaFactory.newClient())
-        .then((producer) => {
-            this.retryProducer = producer;
-            return this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
-                retryTopicName, `change-prop-${retryTopicName}-${this.rule.name}`);
-        })
+        return this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
+            retryTopicName,
+            `change-prop-${retryTopicName}-${this.rule.name}`)
         .then((consumer) => {
             this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
             this.retryConsumer.on('message', (msg) => {
@@ -137,10 +134,10 @@ class RuleExecutor {
 
     _retry(retryMessage) {
         return P.delay(this.rule.spec.retry_delay || DEFAULT_RETRY_DELAY)
-        .then(() => this.retryProducer.sendAsync([{
-            topic: this._retryTopicName(),
-            messages: [ JSON.stringify(retryMessage) ]
-        }]));
+        .then(() => this.hyper.post({
+            uri: '/sys/queue/events',
+            body: [ retryMessage ]
+        }));
     }
 
     _consumerId() {

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -19,7 +19,9 @@ class Kafka {
         this.log = options.log || function() { };
         this.kafkaFactory = new KafkaFactory({
             uri: options.uri || 'localhost:2181/',
-            clientId: options.client_id || 'change-propagation'
+            clientId: options.client_id || 'change-propagation',
+            consume_dc: options.consume_dc,
+            produce_dc: options.produce_dc
         });
         this.staticRules = options.templates || {};
         this.ruleExecutors = {};
@@ -75,7 +77,7 @@ class Kafka {
 
         return this.producer.sendAsync(Object.keys(groupedPerTopic).map((topic) => {
             return {
-                topic: topic,
+                topic: `${this.kafkaFactory.produceDC}.${topic}`,
                 messages: groupedPerTopic[topic]
             };
         }))

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -21,7 +21,8 @@ class Kafka {
             uri: options.uri || 'localhost:2181/',
             clientId: options.client_id || 'change-propagation',
             consume_dc: options.consume_dc,
-            produce_dc: options.produce_dc
+            produce_dc: options.produce_dc,
+            dc_name: options.dc_name
         });
         this.staticRules = options.templates || {};
         this.ruleExecutors = {};
@@ -76,10 +77,8 @@ class Kafka {
         }, {});
 
         return this.producer.sendAsync(Object.keys(groupedPerTopic).map((topic) => {
-            const prefixedTopic = this.kafkaFactory.produceDC ?
-                `${this.kafkaFactory.produceDC}.${topic}` : topic;
             return {
-                topic: prefixedTopic,
+                topic: `${this.kafkaFactory.produceDC}.${topic}`,
                 messages: groupedPerTopic[topic]
             };
         }))

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -76,8 +76,10 @@ class Kafka {
         }, {});
 
         return this.producer.sendAsync(Object.keys(groupedPerTopic).map((topic) => {
+            const prefixedTopic = this.kafkaFactory.produceDC ?
+                `${this.kafkaFactory.produceDC}.${topic}` : topic;
             return {
-                topic: `${this.kafkaFactory.produceDC}.${topic}`,
+                topic: prefixedTopic,
                 messages: groupedPerTopic[topic]
             };
         }))

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -16,8 +16,7 @@ describe('Basic rule management', function() {
     const kafkaFactory = new KafkaFactory({
         uri: 'localhost:2181/', // TODO: find out from the config
         clientId: 'change-prop-test-suite',
-        consume_dc: 'test_dc',
-        produce_dc: 'test_dc'
+        dc_name: 'test_dc'
     });
     let producer;
     let retrySchema;

--- a/test/utils/clean_kafka.sh
+++ b/test/utils/clean_kafka.sh
@@ -16,4 +16,4 @@ dropTopics ( ) {
   fi
 }
 
-dropTopics "test_topic"
+dropTopics "test_dc"


### PR DESCRIPTION
Two changes:

1. We require the user to set up config parameters for produce_dc and consume_dc - it's used as a topic prefix.
2. All event production now go through the production endpoint.

cc @wikimedia/services 