### PR TITLE
Rules: Add the `match_not` predicate (release v0.2.0)

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -106,6 +106,7 @@ class Rule {
         this.shouldRetry = _compileRetryCondition(this.spec.retry_on);
         this.exec = this._processExec(this.spec.exec);
         this._match = this._processMatch(this.spec.match);
+        this._match_not = (this._processMatch(this.spec.match_not) || {}).test;
     }
 
     /**
@@ -115,7 +116,14 @@ class Rule {
      * @return true if no match is set for this rule or if the message matches
      */
     test(message) {
-        return !this._match || !this._match.test || this._match.test(message);
+        var match = true;
+        if (this._match && this._match.test) {
+            match = this._match.test(message);
+        }
+        if (this._match_not) {
+            match = match && !this._match_not(message);
+        }
+        return match;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "change-propagation",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Listens to events from Kafka and delivers them",
   "main": "server.js",
   "repository": {

--- a/test/feature/rule.js
+++ b/test/feature/rule.js
@@ -113,6 +113,45 @@ describe('Rule', function() {
             }, Error);
         });
 
+        it('match_not', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match_not: {meta: {uri: '/my-url/'}}
+            });
+            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+        });
+
+        it('matches match and match_not', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 1},
+                match_not: {meta: {uri: '/my-url/'}}
+            });
+            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+        });
+
+        it('matches match but not match_not', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 1},
+                match_not: {meta: {uri: '/fake/'}}
+            });
+            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+        });
+
+        it('matches match_not but not match', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 10},
+                match_not: {meta: {uri: '/my-url/'}}
+            });
+            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+        });
+
         it('expansion', function() {
             var r = new Rule('rule', {
                 topic: 'nono',


### PR DESCRIPTION
There are situations where we might need to negate the outcome of a rule match test. One such example is updating the summary endpoint for non-wiktionaries. This PR adds the functionality via the `match_not` predicate. If it is present, its condition is evaluated and negated and the message is accepted only if it doesn't match it. This works rather well in conjuction with the `match` predicate: if both are specified, they both need to be evaluated positively in order for the message to be accepted. Note that `match_not` is used only for testing messages, it cannot be used for rule execution expansion.

cc @wikimedia/services 