### PR TITLE
Create sample config for summary and definition updates

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -1,0 +1,73 @@
+num_workers: 0
+logging:
+  name: changeprop
+  level: info
+services:
+  - name: changeprop
+    module: hyperswitch
+    conf:
+      port: 7273
+      spec:
+        x-sub-request-filters:
+          - type: default
+            name: http
+            options:
+              allow:
+                - pattern: /^https?:\/\//
+        title: The Change Propagation root
+        paths:
+          /sys/links:
+            x-modules:
+              - path: sys/backlinks.js
+                options:
+                  templates:
+                    apiURITemplate: 'https://{{message.meta.domain}}/w/api.php'
+          /sys/queue:
+            x-modules:
+              - path: sys/kafka.js
+                options:
+                  uri: 127.0.0.1:2181
+                  dc_name: test_dc
+                  templates:
+
+                    summary_rerender:
+                      topic: resource_change
+                      retry_limit: 2
+                      retry_delay: 500
+                      retry_on:
+                        status:
+                          - '5xx'
+                      match:
+                        meta:
+                          uri: '/^(https?):\/\/[a-zA-Z0-9\:\.]+\/api\/rest_v1\/page\/html\/([^/]+)/'
+                      match_not:
+                        meta:
+                          domain: '/wiktionary.org$/'
+                        tags:
+                          - restbase
+                      exec:
+                        method: get
+                        # Don't encode title since it should be already encoded
+                        uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri[2]}}'
+                        headers:
+                          cache-control: no-cache
+
+                    definition_rerender:
+                      topic: resource_change
+                      retry_limit: 2
+                      retry_delay: 500
+                      retry_on:
+                        status:
+                          - '5xx'
+                      match:
+                        meta:
+                          uri: '/^(https?):\/\/[a-zA-Z0-9\:\.]+\/api\/rest_v1\/page\/html\/([^/]+)/'
+                          domain: '/wiktionary.org$/'
+                      exec:
+                        method: get
+                        # Don't encode title since it should be already encoded
+                        uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri[2]}}'
+                        headers:
+                          cache-control: no-cache
+                        tags:
+                          - restbase

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const ChangeProp = require('../utils/changeProp');
+const KafkaFactory = require('../../lib/kafka_factory');
+const nock = require('nock');
+const uuid = require('cassandra-uuid').TimeUuid;
+
+describe('RESTBase update rules', function() {
+    this.timeout(1000);
+
+    const changeProp = new ChangeProp('config.example.wikimedia.yaml');
+    const kafkaFactory = new KafkaFactory({
+        uri: 'localhost:2181/', // TODO: find out from the config
+        clientId: 'change-prop-test-suite',
+        dc_name: 'test_dc'
+    });
+    let producer;
+
+    before(function() {
+        // Setting up might tike some tome, so disable the timeout
+        this.timeout(0);
+
+        return kafkaFactory.newProducer(kafkaFactory.newClient())
+        .then((newProducer) => {
+            producer = newProducer;
+            return producer.createTopicsAsync([
+                'test_dc.resource_change',
+                'test_dc.change-prop.retry.resource_change'
+            ], false)
+        })
+        .then(() => changeProp.start());
+    });
+
+    it('Should update summary endpoint', () => {
+        const mwAPI = nock('https://en.wikipedia.org', {
+            reqheaders: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .get('/api/rest_v1/page/summary/Main%20Page')
+        .reply(200, { });
+
+        return producer.sendAsync([{
+            topic: 'test_dc.resource_change',
+            messages: [
+                JSON.stringify({
+                    meta: {
+                        topic: 'resource_change',
+                        schema_uri: 'resource_change/1',
+                        uri: 'https://en.wikipedia.org/api/rest_v1/page/html/Main%20Page',
+                        request_id: uuid.now(),
+                        id: uuid.now(),
+                        dt: new Date().toISOString(),
+                        domain: 'en.wikipedia.org'
+                    },
+                    tags: ['restbase']
+                })
+            ]
+        }])
+        .delay(300)
+        .then(() => mwAPI.done())
+        .finally(() => nock.cleanAll());
+    });
+
+    it('Should update definition endpoint', () => {
+        const mwAPI = nock('https://en.wiktionary.org', {
+            reqheaders: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .get('/api/rest_v1/page/definition/Main%20Page')
+        .reply(200, { });
+
+        return producer.sendAsync([{
+            topic: 'test_dc.resource_change',
+            messages: [
+                JSON.stringify({
+                    meta: {
+                        topic: 'resource_change',
+                        schema_uri: 'resource_change/1',
+                        uri: 'https://en.wiktionary.org/api/rest_v1/page/html/Main%20Page',
+                        request_id: uuid.now(),
+                        id: uuid.now(),
+                        dt: new Date().toISOString(),
+                        domain: 'en.wiktionary.org'
+                    },
+                    tags: ['restbase']
+                })
+            ]
+        }])
+        .delay(300)
+        .then(() => mwAPI.done())
+        .finally(() => nock.cleanAll());
+    });
+
+    after(() => changeProp.stop());
+});


### PR DESCRIPTION
Basically it's a loop since the config will live in puppet, but let's have our local copy too for review and testing.

cc @wikimedia/services 