### PR TITLE
Backlinks: Allow users to specify a full MW API request template

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -21,7 +21,10 @@ services:
               - path: sys/backlinks.js
                 options:
                   templates:
-                    apiURITemplate: 'https://{{message.meta.domain}}/w/api.php'
+                    mw_api:
+                        uri: 'https://{{message.meta.domain}}/w/api.php'
+                        headers:
+                          host: '{{message.meta.domain}}'
           /sys/queue:
             x-modules:
               - path: sys/kafka.js

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,7 +24,7 @@ services:
     # per-service config
     conf:
       # the port to bind to
-      port: 7273
+      port: 7272
       # IP address to bind to, all IPs by default
       # interface: localhost # uncomment to only listen on localhost
       # allow cross-domain requests to the API (default '*')

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -6,7 +6,7 @@ services:
   - name: changeprop
     module: hyperswitch
     conf:
-      port: 7273
+      port: 7272
       spec:
         x-sub-request-filters:
           - type: default
@@ -21,7 +21,10 @@ services:
               - path: sys/backlinks.js
                 options:
                   templates:
-                    apiURITemplate: 'https://{{message.meta.domain}}/w/api.php'
+                    mw_api:
+                        uri: 'https://{{message.meta.domain}}/w/api.php'
+                        headers:
+                          host: '{{message.meta.domain}}'
           /sys/queue:
             x-modules:
               - path: sys/kafka.js

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "cassandra-uuid": "^0.0.2",
+    "extend": "^3.0.0",
     "hyperswitch": "^0.4.8",
     "service-runner": "^1.2.2",
     "wmf-kafka-node": "^0.1.0",
     "json-stable-stringify": "^1.0.1"
   },
   "devDependencies": {
-    "extend": "^3.0.0",
     "istanbul": "^0.4.3",
     "mocha": "^2.4.5",
     "mocha-jscs": "^4.2.0",

--- a/sys/backlinks.js
+++ b/sys/backlinks.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const extend = require('extend');
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
 
@@ -8,9 +9,8 @@ const CONTINUE_TOPIC_NAME = 'change-prop.backlinks.continue';
 class BackLinksProcessor {
     constructor(options) {
         this.options = options;
-        this.backLinksRequest = new Template({
+        this.backLinksRequest = new Template(extend(true, {}, options.templates.mw_api, {
             method: 'post',
-            uri: options.templates.apiURITemplate,
             body: {
                 format: 'json',
                 action: 'query',
@@ -20,7 +20,7 @@ class BackLinksProcessor {
                 blcontinue: '{{message.continue}}',
                 bllimit: 500
             }
-        });
+        }));
     }
 
     setup(hyper) {


### PR DESCRIPTION
In production, we call the MW API directly, bypassing nginx and Varnish. In order for that to work, we must set the `host` header in the request. This PR allows the user to set the full MW API request template, and then it extends it with the method and body used to fulfil the backlinks request.

Also: set the port in the config to 7272 as that's what we are using in production.

cc @wikimedia/services 