### PR TITLE
Catch TopicNotExistError and report it properly

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -84,3 +84,9 @@ services:
                           - meta:
                               topic: '{{message.produce_to_topic}}'
                             message: 'test'
+
+                    # This rule is used to verify that change prop doesn't fail with non-existent topics
+                    rule_with_non_existent_topic:
+                      topic: this_topic_does_not_exist
+                      exec:
+                        uri: 'https://test.com'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -84,9 +84,3 @@ services:
                           - meta:
                               topic: '{{message.produce_to_topic}}'
                             message: 'test'
-
-                    # This rule is used to verify that change prop doesn't fail with non-existent topics
-                    rule_with_non_existent_topic:
-                      topic: this_topic_does_not_exist
-                      exec:
-                        uri: 'https://test.com'

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -208,7 +208,10 @@ class RuleExecutor {
                 });
             });
         })
-        .catch(TopicsNotExistError, (e) => this.log('error/topic', e));
+        .catch(TopicsNotExistError, (e) => {
+            this.log('error/topic', e);
+            process.exit(1);
+        });
     }
 }
 

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -210,7 +210,8 @@ class RuleExecutor {
         })
         .catch(TopicsNotExistError, (e) => {
             this.log('error/topic', e);
-            process.exit(1);
+            // Exit async to let the logs get processed.
+            setTimeout(() => process.exit(1), 100);
         });
     }
 }

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -2,6 +2,7 @@
 
 const P = require('bluebird');
 const uuid = require('cassandra-uuid').TimeUuid;
+const TopicsNotExistError = require('wmf-kafka-node/lib/errors').TopicsNotExistError;
 
 const DEFAULT_RETRY_DELAY = 500;
 const DEFAULT_RETRY_LIMIT = 3;
@@ -206,7 +207,8 @@ class RuleExecutor {
                     .finally(() => this._reportMetrics(statName, startTime, message));
                 });
             });
-        });
+        })
+        .catch(TopicsNotExistError, (e) => this.log('error/topic', e));
     }
 }
 

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -277,9 +277,9 @@ describe('Basic rule management', function() {
 
         return producer.sendAsync([{
             topic: 'test_dc.kafka_producing_rule',
-            messages: [ JSON.stringify({
+            messages: [ JSON.stringify(eventWithProperties('test_dc.kafka_producing_rule', {
                 produce_to_topic: 'simple_test_rule'
-            }) ]
+            })) ]
         }])
         .delay(100)
         .then(() => service.done())


### PR DESCRIPTION
Based on morning discussion with @d00rman - do not crash if topic doesn't exist. 

However, I still think we need to crash the service. Non existent topic in a static config means that the service is misconfigured, so we should take it down. As workers do not load updated config when they're respawned any more, on config deployment we will immediately notice that something is wrong, because rolling restart will fail on the first node, while if we swallow an error and just log it, all nodes will be restarted before we notice an error in logstash, thus putting the whole change prop cluster in a loose state. So I propose to add `process.exit(1)` in that catch block. 

When we have dynamic subscriptions, this will change, but we can separate the `subscribe` method to `subscribeStatic` and `subscribeDynamic` - the first one will fail on non-existent topic, the second one will just throw, log error and return 400 to the subscription request origin.

cc @wikimedia/services 