### PR TITLE
Don't rerender definitions for non-main namespaces

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -64,7 +64,9 @@ services:
                           - '5xx'
                       match:
                         meta:
-                          uri: '/^(https?):\/\/[a-zA-Z0-9\:\.]+\/api\/rest_v1\/page\/html\/([^/]+)/'
+                          # These URIs are coming from RESTBase, so we know that article titles will be normalized
+                          # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
+                          uri: '/^(https?):\/\/[a-zA-Z0-9\:\.]+\/api\/rest_v1\/page\/html\/((?:(?!%3a|%3A).)+)$/'
                           domain: '/wiktionary.org$/'
                       exec:
                         method: get


### PR DESCRIPTION
In RESTBase we don't rerender definitions for non-main namespaces, so we need to do the same in change prop. URIs in events in change-prop come from RB, so we're sure that pages from main namespace will not use any namespace aliases etc, so we can just update a regex to not match `%3A` and `%3a` char sequences.

cc @wikimedia/services 