### PR TITLE
Bring mobile-sections update to change-prop

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -43,11 +43,11 @@ services:
                       match:
                         meta:
                           uri: '/^(https?):\/\/[a-zA-Z0-9\:\.]+\/api\/rest_v1\/page\/html\/([^/]+)/'
+                        tags:
+                          - restbase
                       match_not:
                         meta:
                           domain: '/wiktionary.org$/'
-                        tags:
-                          - restbase
                       exec:
                         method: get
                         # Don't encode title since it should be already encoded
@@ -68,11 +68,30 @@ services:
                           # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
                           uri: '/^(https?):\/\/[a-zA-Z0-9\:\.]+\/api\/rest_v1\/page\/html\/((?:(?!%3a|%3A).)+)$/'
                           domain: '/wiktionary.org$/'
+                        tags:
+                          - restbase
                       exec:
                         method: get
                         # Don't encode title since it should be already encoded
                         uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri[2]}}'
                         headers:
                           cache-control: no-cache
+
+                    mobile_rerender:
+                      topic: resource_change
+                      retry_limit: 2
+                      retry_delay: 500
+                      retry_on:
+                        status:
+                          - '5xx'
+                      match:
+                        meta:
+                          uri: '/^(https?):\/\/[a-zA-Z0-9\:\.]+\/api\/rest_v1\/page\/html\/([^/]+)/'
                         tags:
                           - restbase
+                      exec:
+                        method: get
+                        # Don't encode title since it should be already encoded
+                        uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri[2]}}'
+                        headers:
+                          cache-control: no-cache

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -93,6 +93,37 @@ describe('RESTBase update rules', function() {
         .finally(() => nock.cleanAll());
     });
 
+    it('Should update mobile apps endpoint', () => {
+        const mwAPI = nock('https://en.wikipedia.org', {
+            reqheaders: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .get('/api/rest_v1/page/mobile-sections/Main%20Page')
+        .reply(200, { });
+
+        return producer.sendAsync([{
+            topic: 'test_dc.resource_change',
+            messages: [
+                JSON.stringify({
+                    meta: {
+                        topic: 'resource_change',
+                        schema_uri: 'resource_change/1',
+                        uri: 'https://en.wikipedia.org/api/rest_v1/page/html/Main%20Page',
+                        request_id: uuid.now(),
+                        id: uuid.now(),
+                        dt: new Date().toISOString(),
+                        domain: 'en.wikipedia.org'
+                    },
+                    tags: ['restbase']
+                })
+            ]
+        }])
+        .delay(300)
+        .then(() => mwAPI.done())
+        .finally(() => nock.cleanAll());
+    });
+
     it('Should not update definition endpoint for non-main namespace', (done) => {
         const mwAPI = nock('https://en.wiktionary.org', {
             reqheaders: {


### PR DESCRIPTION
One more piece of restbase update migrations.

This is the last PR needed for complete migration of restbase hacky updates functionality to change-prop

cc @wikimedia/services 