### PR TITLE
Improve retry event

### DIFF
--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -166,7 +166,7 @@ class RuleExecutor {
                 schema_uri: 'retry/1',
                 uri: event.meta.uri,
                 request_id: event.meta.request_id,
-                id: uuid.fromDate(now),
+                id: uuid.fromDate(now).toString(),
                 dt: now.toISOString(),
                 domain: event.meta.domain
             },

--- a/test/utils/clean_kafka.sh
+++ b/test/utils/clean_kafka.sh
@@ -16,4 +16,15 @@ dropTopics ( ) {
   fi
 }
 
+check ( ) {
+  PORT=$1
+  SERVICE_NAME=$2
+  if [ `nc localhost ${PORT} < /dev/null; echo $?` != 0 ]; then
+    echo "${SERVICE_NAME} not running, start it first with npm run start-kafka"
+    exit 1
+  fi
+}
+
+check 2181 "Zookeeper"
+check 9092 "Kafka"
 dropTopics "test_dc"


### PR DESCRIPTION
The UUID class is not logged to well - it's internal Buffer end up being several fields with ints in logstash. So, when retry limit is exceeded, we get ugly logs. 

cc @wikimedia/services 