### PR TITLE
Rule execution: Use geometric progression for the retry delay

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -4,6 +4,10 @@ const stringify = require('json-stable-stringify');
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
 
+const DEFAULT_RETRY_DELAY = 500;
+const DEFAULT_RETRY_FACTOR = 6;
+const DEFAULT_RETRY_LIMIT = 5;
+
 /**
  * Creates a JS function that verifies property equality
  *
@@ -107,6 +111,9 @@ class Rule {
         this.exec = this._processExec(this.spec.exec);
         this._match = this._processMatch(this.spec.match);
         this._match_not = (this._processMatch(this.spec.match_not) || {}).test;
+        this.spec.retry_delay = this.spec.retry_delay || DEFAULT_RETRY_DELAY;
+        this.spec.retry_limit = this.spec.retry_limit || DEFAULT_RETRY_LIMIT;
+        this.spec.retry_factor = this.spec.retry_factor || DEFAULT_RETRY_FACTOR;
     }
 
     /**

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -4,9 +4,6 @@ const P = require('bluebird');
 const uuid = require('cassandra-uuid').TimeUuid;
 const TopicsNotExistError = require('wmf-kafka-node/lib/errors').TopicsNotExistError;
 
-const DEFAULT_RETRY_DELAY = 500;
-const DEFAULT_RETRY_LIMIT = 3;
-
 /**
  * A rule executor managing matching and execution of a single rule
  */
@@ -147,7 +144,10 @@ class RuleExecutor {
     }
 
     _retry(retryMessage) {
-        return P.delay(this.rule.spec.retry_delay || DEFAULT_RETRY_DELAY)
+        const spec = this.rule.spec;
+        const delay = spec.retry_delay *
+            Math.pow(spec.retry_factor, spec.retry_limit - retryMessage.retries_left);
+        return P.delay(delay)
         .then(() => this.hyper.post({
             uri: '/sys/queue/events',
             body: [ retryMessage ]
@@ -171,8 +171,7 @@ class RuleExecutor {
                 domain: event.meta.domain
             },
             emitter_id: this._consumerId(),
-            retries_left: retriesLeft === undefined ?
-                (this.rule.spec.retry_limit || DEFAULT_RETRY_LIMIT) : retriesLeft,
+            retries_left: retriesLeft === undefined ? this.rule.spec.retry_limit : retriesLeft,
             original_event: event,
             reason: errorRes && errorRes.body && errorRes.body.title
         };


### PR DESCRIPTION
The naive approach to retries is not satisfactory. If there is an outage somewhere in the request path (RESTBase, MW, etc), retrying three times 0.5 seconds apart will not help, as these are usually situations where human intervention is needed.

We now use geometric progression to allow sufficient time to pass by so that retries have a chance of succeeding. For that, we introduce a third parameter - `retry_factor` - which is the basis of the progression, and its default value is set to 6. That gives us the following delays if all of the defaults are used: 0.5s, 3s, 18s, 1m48s, 10m48s and 1h4m48s