### PR TITLE
Improve metrics reporting

### DIFF
--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -49,7 +49,7 @@ class RuleExecutor {
         return consumer;
     }
 
-    _exec(event) {
+    _exec(event, statName) {
         const rule = this.rule;
         if (!rule.test(event)) {
             // no match, drop the message
@@ -59,11 +59,15 @@ class RuleExecutor {
 
         this.log(`trace/${rule.name}`, { msg: 'Event message received', event: event });
 
+        const startTime = Date.now();
         const expander = {
             message: event,
             match: rule.expand(event)
         };
-        return P.each(rule.exec, (tpl) => this.hyper.request(tpl.expand(expander)));
+        return P.each(rule.exec, (tpl) => this.hyper.request(tpl.expand(expander)))
+        .finally(() => {
+            this.hyper.metrics.endTiming([statName + '_exec'], startTime);
+        });
     }
 
     _safeParse(message) {
@@ -102,7 +106,6 @@ class RuleExecutor {
         .then((consumer) => {
             this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
             this.retryConsumer.on('message', (msg) => {
-                const startTime = Date.now();
                 const statName = this.hyper.metrics.normalizeName(this.rule.name + '_retry');
                 let message;
                 return P.try(() => {
@@ -111,6 +114,9 @@ class RuleExecutor {
                         // Don't retry if we can't parse an event, just log.
                         return;
                     }
+
+                    // Latency from the original event creation time to dequeue time
+                    this.hyper.metrics.endTiming([statName + '_delay'], new Date(message.meta.dt));
 
                     if (message.emitter_id !== this._consumerId()) {
                         // Not our business, don't care
@@ -122,7 +128,7 @@ class RuleExecutor {
                         return;
                     }
 
-                    return this._exec(message.original_event)
+                    return this._exec(message.original_event, statName)
                     .catch((e) => {
                         const retryMessage = this._constructRetryMessage(message.original_event,
                             e, message.retries_left - 1);
@@ -131,19 +137,9 @@ class RuleExecutor {
                         }
                     });
                 })
-                .then(() => this.retryConsumer.commitAsync())
-                .finally(() => this._reportMetrics(statName, startTime, message));
+                .then(() => this.retryConsumer.commitAsync());
             });
         });
-    }
-
-    _reportMetrics(statName, startTime, message) {
-        // Latency of an individual message processing
-        this.hyper.metrics.endTiming([statName + '_exec'], startTime);
-        if (message) {
-            // Latency from the original event creation time
-            this.hyper.metrics.endTiming([statName + '_delay'], new Date(message.meta.dt));
-        }
     }
 
     _retry(retryMessage) {
@@ -187,7 +183,6 @@ class RuleExecutor {
             .then((consumer) => {
                 this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
                 this.consumer.on('message', (msg) => {
-                    const startTime = Date.now();
                     const statName = this.hyper.metrics.normalizeName(this.rule.name);
                     let message;
                     return P.try(() => {
@@ -196,15 +191,19 @@ class RuleExecutor {
                             // Don't retry if we can't parse an event, just log.
                             return;
                         }
-                        return this._exec(message)
+
+                        // Latency from the original event creation time to dequeue time
+                        this.hyper.metrics.endTiming([statName + '_delay'],
+                            new Date(message.meta.dt));
+
+                        return this._exec(message, statName)
                         .catch((e) => {
                             if (this.rule.shouldRetry(e)) {
                                 return this._retry(this._constructRetryMessage(message, e));
                             }
                         });
                     })
-                    .then(() => this.consumer.commitAsync())
-                    .finally(() => this._reportMetrics(statName, startTime, message));
+                    .then(() => this.consumer.commitAsync());
                 });
             });
         })


### PR DESCRIPTION
Currently the metrics for `exec` and `delay` include the rejected events too. This makes a mean exec time incorrect. Instead, the `delay` metrics will show the time from event creation to event dequeuing, and `exec` metric should report the execution timing only if the event was actually executed, not rejected.

cc @wikimedia/services 