### PR TITLE
No automatic redirects or retries

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -58,6 +58,8 @@ services:
                         method: get
                         # Don't encode title since it should be already encoded
                         uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri[2]}}'
+                        query:
+                          redirect: false
                         headers:
                           cache-control: no-cache
 
@@ -80,6 +82,8 @@ services:
                         method: get
                         # Don't encode title since it should be already encoded
                         uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri[2]}}'
+                        query:
+                          redirect: false
                         headers:
                           cache-control: no-cache
 
@@ -96,6 +100,8 @@ services:
                       exec:
                         method: get
                         uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri[2]}}'
+                        query:
+                          redirect: false
                         headers:
                           cache-control: no-cache
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -184,6 +184,8 @@ class Rule {
             }
             req.method = req.method || 'get';
             req.headers = req.headers || {};
+            req.followRedirect = false;
+            req.retries = 0;
             templates.push(new Template(req));
         }
         return templates;

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -40,6 +40,7 @@ describe('RESTBase update rules', function() {
             }
         })
         .get('/api/rest_v1/page/summary/Main%20Page')
+        .query({ redirect: false })
         .reply(200, { });
 
         return producer.sendAsync([{
@@ -71,6 +72,7 @@ describe('RESTBase update rules', function() {
             }
         })
         .get('/api/rest_v1/page/definition/Main%20Page')
+        .query({ redirect: false })
         .reply(200, { });
 
         return producer.sendAsync([{
@@ -102,6 +104,7 @@ describe('RESTBase update rules', function() {
             }
         })
         .get('/api/rest_v1/page/mobile-sections/Main%20Page')
+        .query({ redirect: false })
         .reply(200, { });
 
         return producer.sendAsync([{


### PR DESCRIPTION
The `request` library automatically follows redirects for GET requests which return a 3xx code. This is not a desirable property for change propagation, so disable it. The `preq` library automatically retries failed requests, but since change propagation has its own retry logic, disable that as well.

Additionally, supply the `?redirect=false` query parameter to RESTBase when doing the update requests.

Bug: [T134483](https://phabricator.wikimedia.org/T134483)