### PR TITLE
Make retry defaults more conservative

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -4,9 +4,9 @@ const stringify = require('json-stable-stringify');
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
 
-const DEFAULT_RETRY_DELAY = 500;
-const DEFAULT_RETRY_FACTOR = 6;
-const DEFAULT_RETRY_LIMIT = 5;
+const DEFAULT_RETRY_DELAY = 60000;  // One minute minimum retry delay
+const DEFAULT_RETRY_FACTOR = 6;     // Exponential back-off
+const DEFAULT_RETRY_LIMIT = 2;      // At most two retries
 
 /**
  * Creates a JS function that verifies property equality


### PR DESCRIPTION
Request failures are often triggered by expensive requests or overloaded
infrastructure. To avoid excerbating issues, we should be very conservative
about retry delays and number.

To this effect, this patch sets

- the minimum retry delay to one minute, and
- the maximum number of retries to two.

Bug: T134456