### PR TITLE
Concurrency limiting

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -37,6 +37,7 @@ services:
                 options:
                   uri: 127.0.0.1:2181
                   dc_name: test_dc
+                  concurrency: 250
                   templates:
 
                     summary_rerender:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,6 +43,6 @@ services:
               - path: sys/kafka.js
                 options:
                   uri: 127.0.0.1:2181
-                  consume_dc: default
-                  produce_dc: default
+                  dc_name: default
+                  concurrency: 10
                   templates: {}

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -46,15 +46,23 @@ class RuleExecutor {
         return consumer;
     }
 
-    _exec(event, statName) {
-        const rule = this.rule;
-        if (!rule.test(event)) {
-            // no match, drop the message
-            this.log(`debug/${rule.name}`, { msg: 'Dropping event message', event: event });
-            return P.resolve();
+    _test(event) {
+        if (this.rule.test(event)) {
+            return true;
         }
+        // no match, drop the message
+        this.log(`debug/${this.rule.name}`, { msg: 'Dropping event message', event: event });
+        return false;
+    }
+
+    _exec(event, statName, statDelayStartTime) {
+        const rule = this.rule;
 
         this.log(`trace/${rule.name}`, { msg: 'Event message received', event: event });
+
+        // latency from the original event creation time to execution time
+        this.hyper.metrics.endTiming([statName + '_delay'],
+            statDelayStartTime || new Date(event.meta.dt));
 
         const startTime = Date.now();
         const expander = {
@@ -112,9 +120,6 @@ class RuleExecutor {
                         return;
                     }
 
-                    // Latency from the original event creation time to dequeue time
-                    this.hyper.metrics.endTiming([statName + '_delay'], new Date(message.meta.dt));
-
                     if (message.emitter_id !== this._consumerId()) {
                         // Not our business, don't care
                         return;
@@ -125,7 +130,14 @@ class RuleExecutor {
                         return;
                     }
 
-                    return this._exec(message.original_event, statName)
+                    if (!this._test(message.original_event)) {
+                        // doesn't match any more, possibly meaning
+                        // the rule has been changed since we last
+                        // executed it on the message
+                        return;
+                    }
+
+                    return this._exec(message.original_event, statName, new Date(message.meta.dt))
                     .catch((e) => {
                         const retryMessage = this._constructRetryMessage(message.original_event,
                             e, message.retries_left - 1);
@@ -186,14 +198,10 @@ class RuleExecutor {
                     let message;
                     return P.try(() => {
                         message = this._safeParse(msg.value);
-                        if (!message) {
-                            // Don't retry if we can't parse an event, just log.
+                        if (!message || !this._test(message)) {
+                            // no message or no match, we are done here
                             return;
                         }
-
-                        // Latency from the original event creation time to dequeue time
-                        this.hyper.metrics.endTiming([statName + '_delay'],
-                            new Date(message.meta.dt));
 
                         return this._exec(message, statName)
                         .catch((e) => {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -13,13 +13,15 @@ class RuleExecutor {
      *
      * @param {Rule} rule
      * @param {KafkaFactory} kafkaFactory
+     * @param {TaskQueue} taskQueue
      * @param {Object} hyper
      * @param {function} log
      * @constructor
      */
-    constructor(rule, kafkaFactory, hyper, log) {
+    constructor(rule, kafkaFactory, taskQueue, hyper, log) {
         this.rule = rule;
         this.kafkaFactory = kafkaFactory;
+        this.taskQueue = taskQueue;
         this.hyper = hyper;
         this.log = log;
     }
@@ -97,12 +99,14 @@ class RuleExecutor {
         }
         return false;
     }
+
     /**
      * Set's up a consumer a retry queue
      *
      * @private
      */
     _setUpRetryTopic() {
+        var self = this;
         const retryTopicName = this._retryTopicName();
 
         return this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
@@ -112,41 +116,41 @@ class RuleExecutor {
             this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
             this.retryConsumer.on('message', (msg) => {
                 const statName = this.hyper.metrics.normalizeName(this.rule.name + '_retry');
-                let message;
-                return P.try(() => {
-                    message = this._safeParse(msg.value);
-                    if (!message) {
-                        // Don't retry if we can't parse an event, just log.
-                        return;
-                    }
+                let message = this._safeParse(msg.value);
+                if (!message) {
+                    // Don't retry if we can't parse an event, just log.
+                    return;
+                }
 
-                    if (message.emitter_id !== this._consumerId()) {
-                        // Not our business, don't care
-                        return;
-                    }
+                if (message.emitter_id !== this._consumerId()) {
+                    // Not our business, don't care
+                    return;
+                }
 
-                    if (this._isLimitExceeded(message)) {
-                        // We've don our best, give up
-                        return;
-                    }
+                if (this._isLimitExceeded(message)) {
+                    // We've don our best, give up
+                    return;
+                }
 
-                    if (!this._test(message.original_event)) {
-                        // doesn't match any more, possibly meaning
-                        // the rule has been changed since we last
-                        // executed it on the message
-                        return;
-                    }
+                if (!this._test(message.original_event)) {
+                    // doesn't match any more, possibly meaning
+                    // the rule has been changed since we last
+                    // executed it on the message
+                    return;
+                }
 
-                    return this._exec(message.original_event, statName, new Date(message.meta.dt))
-                    .catch((e) => {
-                        const retryMessage = this._constructRetryMessage(message.original_event,
+                return self.taskQueue.enqueue({
+                    consumer,
+                    exec: self._exec.bind(self, message.original_event, statName,
+                        new Date(message.meta.dt)),
+                    catch: (e) => {
+                        const retryMessage = self._constructRetryMessage(message.original_event,
                             e, message.retries_left - 1);
-                        if (this.rule.shouldRetry(e) && !this._isLimitExceeded(retryMessage)) {
-                            return this._retry(retryMessage);
+                        if (self.rule.shouldRetry(e) && !self._isLimitExceeded(retryMessage)) {
+                            return self._retry(retryMessage);
                         }
-                    });
-                })
-                .then(() => this.retryConsumer.commitAsync());
+                    }
+                });
             });
         });
     }
@@ -156,15 +160,10 @@ class RuleExecutor {
         const delay = spec.retry_delay *
             Math.pow(spec.retry_factor, spec.retry_limit - retryMessage.retries_left);
         return P.delay(delay)
-        .then(() => {
-            const now = new Date();
-            retryMessage.meta.id = uuid.fromDate(now).toString();
-            retryMessage.meta.dt = now.toISOString();
-            return this.hyper.post({
-                uri: '/sys/queue/events',
-                body: [ retryMessage ]
-            });
-        });
+        .then(() => this.hyper.post({
+            uri: '/sys/queue/events',
+            body: [ retryMessage ]
+        }));
     }
 
     _consumerId() {
@@ -190,6 +189,7 @@ class RuleExecutor {
     }
 
     subscribe() {
+        const self = this;
         const rule = this.rule;
         const client = this.kafkaFactory.newClient();
         return this._setUpRetryTopic()
@@ -197,24 +197,24 @@ class RuleExecutor {
             return this.kafkaFactory.newConsumer(client, rule.topic, `change-prop-${rule.name}`)
             .then((consumer) => {
                 this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
+                this.taskQueue.addConsumer(this.consumer);
                 this.consumer.on('message', (msg) => {
                     const statName = this.hyper.metrics.normalizeName(this.rule.name);
-                    let message;
-                    return P.try(() => {
-                        message = this._safeParse(msg.value);
-                        if (!message || !this._test(message)) {
-                            // no message or no match, we are done here
-                            return;
-                        }
+                    let message = this._safeParse(msg.value);
+                    if (!message || !this._test(message)) {
+                        // no message or no match, we are done here
+                        return;
+                    }
 
-                        return this._exec(message, statName)
-                        .catch((e) => {
-                            if (this.rule.shouldRetry(e)) {
-                                return this._retry(this._constructRetryMessage(message, e));
+                    return self.taskQueue.enqueue({
+                        consumer,
+                        exec: self._exec.bind(self, message, statName),
+                        catch: (e) => {
+                            if (self.rule.shouldRetry(e)) {
+                                return self._retry(self._constructRetryMessage(message, e));
                             }
-                        });
-                    })
-                    .then(() => this.consumer.commitAsync());
+                        }
+                    });
                 });
             });
         })

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -156,10 +156,15 @@ class RuleExecutor {
         const delay = spec.retry_delay *
             Math.pow(spec.retry_factor, spec.retry_limit - retryMessage.retries_left);
         return P.delay(delay)
-        .then(() => this.hyper.post({
-            uri: '/sys/queue/events',
-            body: [ retryMessage ]
-        }));
+        .then(() => {
+            const now = new Date();
+            retryMessage.meta.id = uuid.fromDate(now).toString();
+            retryMessage.meta.dt = now.toISOString();
+            return this.hyper.post({
+                uri: '/sys/queue/events',
+                body: [ retryMessage ]
+            });
+        });
     }
 
     _consumerId() {
@@ -167,15 +172,14 @@ class RuleExecutor {
     }
 
     _constructRetryMessage(event, errorRes, retriesLeft) {
-        const now = new Date();
         return {
             meta: {
                 topic: this._retryTopicName(),
                 schema_uri: 'retry/1',
                 uri: event.meta.uri,
                 request_id: event.meta.request_id,
-                id: uuid.fromDate(now).toString(),
-                dt: now.toISOString(),
+                id: undefined, // will be filled later
+                dt: undefined, // will be filled later
                 domain: event.meta.domain
             },
             emitter_id: this._consumerId(),

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -1,0 +1,104 @@
+'use strict';
+
+
+const EventEmitter = require('events');
+const P = require('bluebird');
+
+
+/** @const {number} the dafault queue size */
+const DEFAULT_SIZE = 100;
+
+
+/**
+ * A class representing the task queue used in processing events.
+ */
+class TaskQueue extends EventEmitter {
+
+    /**
+     * Creates a new task queue instance
+     *
+     * @param {Object} [options={}]
+     * @param {number} [options.size=DEFAULT_SIZE] the maximum number of tasks in the queue
+     *
+     * @constructor
+     */
+    constructor(options) {
+        super();
+        options = options || {};
+        this._max_size = options.size || DEFAULT_SIZE;
+        this._queue = [];
+        this._waiting = [];
+        this._consumers = [];
+        this.on('task_completed', this._deferred.bind(this));
+    }
+
+    /**
+     * Adds a consumer to the queue's list of consumers, which are used to pause
+     * and resume them
+     *
+     * @param {HighLevelConsumer} consumer
+     * @returns true if the consumer has been added, false if it has already been
+     *               present in the list of consumers
+     */
+    addConsumer(consumer) {
+        if (this._consumers.some((item) => item === consumer)) {
+            return false;
+        }
+        this._consumers.push(consumer);
+        return true;
+    }
+
+    /**
+     * Enqueues a task on the queue. If the queue is full, the task will be placed on a waiting
+     * list until enough tasks have been dequeued.
+     *
+     * @param {Object} task the task to enqueue
+     * @param {number} task.id the message ID of the event
+     * @param {HighLevelConsumer} task.consumer the Kafka consumer object used for offset commit
+     * @param {Function} task.exec the promise to execute
+     * @param {Function} task.catch the promise to execute in case the task's execution fails
+     * @returns {Boolean} true if the task has been enqueued, false if it has been put on the
+     *                    waiting list
+     */
+    enqueue(task) {
+        if (this._queue.length >= this._max_size) {
+            // too many tasks running already, defer this one
+            this._defer(task);
+            return false;
+        }
+        // ok, the execution can start right away
+        this._start(task);
+        return true;
+    }
+
+    _start(task) {
+        this._queue.push(task);
+        task._p = P.try(() => {
+            return task.exec().finally(() => {
+                this._queue = this._queue.filter((item) => item !== task);
+                this.emit('task_completed');
+            }).catch(task.catch);
+        }).then(task.consumer.commitAsync.bind(task.consumer));
+    }
+
+    _defer(task) {
+        // put the task in the waiting queue and pause the consumers
+        this._waiting.push(task);
+        this._consumers.forEach((consumer) => consumer.pause());
+    }
+
+    _deferred() {
+        // enqueue any outstanding tasks
+        while (this._queue.length < this._max_size && this._waiting.length > 0) {
+            this._start(this._waiting.shift());
+        }
+        // resume the consumers if the queue has empty slots
+        if (this._queue.length < this._max_size) {
+            this._consumers.filter((cons) => cons.paused).forEach((cons) => cons.resume());
+        }
+    }
+
+}
+
+
+module.exports = TaskQueue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "change-propagation",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Listens to events from Kafka and delivers them",
   "main": "server.js",
   "repository": {


### PR DESCRIPTION
This PR brings concurrency limiting to event executions. When a message is received, it is sent to the task queue, which either starts the execution right away, or it defers it for later execution, depending on the number of tasks currently in execution. When a task is completed, the list of pending tasks is consulted and, if there are outstanding ones, they are put in the queue.

Note that this PR focuses solely on concurrency limiting, as it is a blocker for re-enabling change propagation in production. A subsequent PR will deal with commit offsets.

Bug: [T134456](https://phabricator.wikimedia.org/T134456)