### PR TITLE
Commit only offsets that were already processed

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -101,8 +101,10 @@ class KafkaFactory {
      * @param {string} topic topic to commit offset for
      * @param {Object} offsets offset values to commit for partitions. Object keys
      *                         represent partitions, values - offsets.
+     * @param {Function} shouldResume a no-arg callback checking whether the consumer
+     *                                should be resumed after offsets have been committed
      */
-    static commit(consumer, topic, offsets) {
+    static commit(consumer, topic, offsets, shouldResume) {
         function setOffsets(values) {
             Object.keys(values).forEach((partition) => {
                 consumer.setOffset(topic, partition, values[partition]);
@@ -119,7 +121,9 @@ class KafkaFactory {
         return consumer.commitAsync(true)
         .then(() => {
             setOffsets(oldOffsets);
-            consumer.resume();
+            if (shouldResume()) {
+                consumer.resume();
+            }
         });
     }
 }

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -93,6 +93,35 @@ class KafkaFactory {
     get produceDC() {
         return this.kafkaConf.dc_name || this.kafkaConf.produce_dc || 'datacenter1';
     }
+
+    /**
+     * Commit a specific offset.
+     *
+     * @param {kafka.HighLevelConsumer} consumer a consumer to commit offset for
+     * @param {string} topic topic to commit offset for
+     * @param {Object} offsets offset values to commit for partitions. Object keys
+     *                         represent partitions, values - offsets.
+     */
+    static commit(consumer, topic, offsets) {
+        function setOffsets(values) {
+            Object.keys(values).forEach((partition) => {
+                consumer.setOffset(topic, partition, values[partition]);
+            });
+        }
+
+        const oldOffsets = {};
+        consumer.pause();
+        consumer.topicPayloads.filter((p) => p.topic === topic)
+        .forEach((p) => {
+            oldOffsets[p.partition] = p.offset;
+        });
+        setOffsets(offsets);
+        return consumer.commitAsync(true)
+        .then(() => {
+            setOffsets(oldOffsets);
+            consumer.resume();
+        });
+    }
 }
 
 module.exports = KafkaFactory;

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -3,6 +3,7 @@
 const P = require('bluebird');
 const uuid = require('cassandra-uuid').TimeUuid;
 const TopicsNotExistError = require('wmf-kafka-node/lib/errors').TopicsNotExistError;
+const Task = require('./task');
 
 /**
  * A rule executor managing matching and execution of a single rule
@@ -106,7 +107,6 @@ class RuleExecutor {
      * @private
      */
     _setUpRetryTopic() {
-        var self = this;
         const retryTopicName = this._retryTopicName();
 
         return this.kafkaFactory.newConsumer(this.kafkaFactory.newClient(),
@@ -139,18 +139,17 @@ class RuleExecutor {
                     return;
                 }
 
-                return self.taskQueue.enqueue({
-                    consumer,
-                    exec: self._exec.bind(self, message.original_event, statName,
-                        new Date(message.meta.dt)),
-                    catch: (e) => {
-                        const retryMessage = self._constructRetryMessage(message.original_event,
+                return this.taskQueue.enqueue(new Task(consumer, message,
+                    this._exec.bind(this, message.original_event,
+                        statName, new Date(message.meta.dt)),
+                    (e) => {
+                        const retryMessage = this._constructRetryMessage(message.original_event,
                             e, message.retries_left - 1);
-                        if (self.rule.shouldRetry(e) && !self._isLimitExceeded(retryMessage)) {
-                            return self._retry(retryMessage);
+                        if (this.rule.shouldRetry(e) && !this._isLimitExceeded(retryMessage)) {
+                            return this._retry(retryMessage);
                         }
                     }
-                });
+                ));
             });
         });
     }
@@ -206,15 +205,16 @@ class RuleExecutor {
                         return;
                     }
 
-                    return self.taskQueue.enqueue({
+                    return self.taskQueue.enqueue(new Task(
                         consumer,
-                        exec: self._exec.bind(self, message, statName),
-                        catch: (e) => {
+                        msg,
+                        self._exec.bind(self, message, statName),
+                        (e) => {
                             if (self.rule.shouldRetry(e)) {
                                 return self._retry(self._constructRetryMessage(message, e));
                             }
                         }
-                    });
+                    ));
                 });
             });
         })

--- a/lib/task.js
+++ b/lib/task.js
@@ -78,6 +78,18 @@ class Task {
     catch(e) {
         return this._catcher(e);
     }
+
+    /**
+     * Checks whether other task was for the same consumerGroup, topic and partition as this one.
+     *
+     * @param {Task} otherTask
+     * @returns {boolean}
+     */
+    isTaskForSamePartition(otherTask) {
+        return otherTask && otherTask.consumerGroup === this.consumerGroup
+            && otherTask.topic === this.topic
+            && otherTask.partition === this.partition;
+    }
 }
 
 module.exports = Task;

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,0 +1,83 @@
+"use strict";
+
+/**
+ * Represents a task for TaskQueue
+ */
+class Task {
+    /**
+     * Constructs a new instance of the task
+     *
+     * @param {HighLevelConsumer} consumer the consumer which the message was emitted by
+     * @param {Object} message the event message
+     * @param {Function} executor function to call to execute the task
+     * @param {Function} catcher function to call if execution errors
+     */
+    constructor(consumer, message, executor, catcher) {
+        this._consumer = consumer;
+        this._message = message;
+        this._executor = executor;
+        this._catcher = catcher;
+    }
+
+    /**
+     * A consumer which the message was emitted by
+     *
+     * @returns {HighLevelConsumer}
+     */
+    get consumer() {
+        return this._consumer;
+    }
+
+    /**
+     * A topic which the message belongs to
+     * @returns {string}
+     */
+    get topic() {
+        return this._message.topic;
+    }
+
+    /**
+     * A partition which the message belongs to
+     *
+     * @returns {number}
+     */
+    get partition() {
+        return this._message.partition;
+    }
+
+    /**
+     * An offset of the message which created this task
+     *
+     * @returns {number}
+     */
+    get offset() {
+        return this._message.offset;
+    }
+
+    /**
+     * A consumer group which the task belongs to
+     *
+     * @returns {string}
+     */
+    get consumerGroup() {
+        return this._consumer.options.groupId;
+    }
+
+    /**
+     * Executes the task
+     */
+    exec() {
+        return this._executor();
+    }
+
+    /**
+     * Executes a catcher
+     *
+     * @param {Error} e an error that caused a catch
+     */
+    catch(e) {
+        return this._catcher(e);
+    }
+}
+
+module.exports = Task;

--- a/lib/task.js
+++ b/lib/task.js
@@ -16,7 +16,7 @@ class Task {
         this._consumer = consumer;
         this._message = message;
         this._executor = executor;
-        this._catcher = catcher;
+        this.catch = catcher;
     }
 
     /**
@@ -68,15 +68,6 @@ class Task {
      */
     exec() {
         return this._executor();
-    }
-
-    /**
-     * Executes a catcher
-     *
-     * @param {Error} e an error that caused a catch
-     */
-    catch(e) {
-        return this._catcher(e);
     }
 
     /**

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -124,7 +124,7 @@ class TaskQueue extends EventEmitter {
                 this._updatePendingCommits(task);
                 this._queue = this._queue.filter((item) => item !== task);
                 this.emit('task_completed');
-            }).catch(task.catch.bind(task));
+            }).catch(task.catch);
         });
     }
 

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -6,8 +6,20 @@ const P = require('bluebird');
 const KafkaFactory = require('./kafka_factory');
 
 
-/** @const {number} the dafault queue size */
+/**
+ * The dafault queue size
+ *
+ * @type {number}
+ * @const
+ */
 const DEFAULT_SIZE = 100;
+
+/**
+ * The default maximum delay to commit the offsets
+ *
+ * @const
+ * @type {number}
+ */
 const COMMIT_TIMEOUT = 100;
 
 
@@ -21,7 +33,8 @@ class TaskQueue extends EventEmitter {
      *
      * @param {Object} [options={}]
      * @param {number} [options.size=DEFAULT_SIZE] the maximum number of tasks in the queue
-     * @param {number} [options.commitTimeout=COMMIT_TIMEOUT] the maximum delay to commit the offset
+     * @param {number} [options.commitTimeout=COMMIT_TIMEOUT] the maximum delay to commit
+     *                                                        the offsets
      * @constructor
      */
     constructor(options) {
@@ -29,6 +42,7 @@ class TaskQueue extends EventEmitter {
         options = options || {};
         this._max_size = options.size || DEFAULT_SIZE;
         this._commit_timeout = options.commitTimeout || COMMIT_TIMEOUT;
+        this._isPaused = false;
         this._queue = [];
         this._waiting = [];
         this._consumers = [];
@@ -36,7 +50,6 @@ class TaskQueue extends EventEmitter {
         this._pendingCommits = new Map();
 
         this.on('task_completed', this._deferred.bind(this));
-        this.on('task_completed', this._commitOffsets.bind(this));
     }
 
     /**
@@ -84,9 +97,10 @@ class TaskQueue extends EventEmitter {
      * @private
      */
     _updatePendingCommits(task) {
-        const current = this._pendingCommits.get(task.consumer)
-            && this._pendingCommits.get(task.consumer)[task.topic]
-            && this._pendingCommits.get(task.consumer)[task.topic][task.partition];
+        let consumerOffsets = this._pendingCommits.get(task.consumer);
+        const current = consumerOffsets
+            && consumerOffsets[task.topic]
+            && consumerOffsets[task.topic][task.partition];
         const pendingPartitionTasks = this._queue
         .filter(task.isTaskForSamePartition.bind(task))
         .map((item) => item.offset);
@@ -103,12 +117,12 @@ class TaskQueue extends EventEmitter {
             return;
         }
 
-        if (!this._pendingCommits.has(task.consumer)) {
-            this._pendingCommits.set(task.consumer, {});
+        if (!consumerOffsets) {
+            consumerOffsets = {};
+            this._pendingCommits.set(task.consumer, consumerOffsets);
         }
-        this._pendingCommits.get(task.consumer)[task.topic] =
-            this._pendingCommits.get(task.consumer)[task.topic] || {};
-        this._pendingCommits.get(task.consumer)[task.topic][task.partition] = newOffset;
+        consumerOffsets[task.topic] = consumerOffsets[task.topic] || {};
+        consumerOffsets[task.topic][task.partition] = newOffset;
     }
 
     /**
@@ -138,6 +152,7 @@ class TaskQueue extends EventEmitter {
         // put the task in the waiting queue and pause the consumers
         this._waiting.push(task);
         this._consumers.forEach((consumer) => consumer.pause());
+        this._isPaused = true;
     }
 
     /**
@@ -146,6 +161,8 @@ class TaskQueue extends EventEmitter {
      * @private
      */
     _deferred() {
+        this._commitOffsets();
+
         // enqueue any outstanding tasks
         while (this._queue.length < this._max_size && this._waiting.length > 0) {
             this._start(this._waiting.shift());
@@ -153,6 +170,7 @@ class TaskQueue extends EventEmitter {
         // resume the consumers if the queue has empty slots
         if (this._queue.length < this._max_size) {
             this._consumers.filter((cons) => cons.paused).forEach((cons) => cons.resume());
+            this._isPaused = false;
         }
     }
 
@@ -167,13 +185,12 @@ class TaskQueue extends EventEmitter {
         }
 
         setTimeout(() => {
-            for (let entry of this._pendingCommits.entries()) {
-                const consumer = entry[0];
-                const topicsOffsets = entry[1];
+            this._pendingCommits.forEach((topicsOffsets, consumer) => {
                 Object.keys(topicsOffsets).forEach((topic) => {
-                    KafkaFactory.commit(consumer, topic, topicsOffsets[topic]);
+                    KafkaFactory.commit(consumer, topic,
+                        topicsOffsets[topic], () => !this._isPaused);
                 });
-            }
+            });
             this._pendingCommits = new Map();
             this._commitScheduled = false;
         }, this._commit_timeout);

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -33,7 +33,7 @@ class TaskQueue extends EventEmitter {
      *
      * @param {Object} [options={}]
      * @param {number} [options.size=DEFAULT_SIZE] the maximum number of tasks in the queue
-     * @param {number} [options.commitTimeout=COMMIT_TIMEOUT] the maximum delay to commit
+     * @param {number} [options.commit_timeout=COMMIT_TIMEOUT] the maximum delay to commit
      *                                                        the offsets
      * @constructor
      */
@@ -41,7 +41,7 @@ class TaskQueue extends EventEmitter {
         super();
         options = options || {};
         this._max_size = options.size || DEFAULT_SIZE;
-        this._commit_timeout = options.commitTimeout || COMMIT_TIMEOUT;
+        this._commitTimeout = options.commit_timeout || COMMIT_TIMEOUT;
         this._isPaused = false;
         this._queue = [];
         this._waiting = [];
@@ -193,7 +193,7 @@ class TaskQueue extends EventEmitter {
             });
             this._pendingCommits = new Map();
             this._commitScheduled = false;
-        }, this._commit_timeout);
+        }, this._commitTimeout);
         this._commitScheduled = true;
     }
 }

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -87,10 +87,8 @@ class TaskQueue extends EventEmitter {
         const current = this._pendingCommits.get(task.consumer)
             && this._pendingCommits.get(task.consumer)[task.topic]
             && this._pendingCommits.get(task.consumer)[task.topic][task.partition];
-        const pendingPartitionTasks = this._queue.filter((item) =>
-                item.consumerGroup === task.consumerGroup
-                && item.topic === task.topic
-                && item.partition === task.partition)
+        const pendingPartitionTasks = this._queue
+        .filter(task.isTaskForSamePartition.bind(task))
         .map((item) => item.offset);
         let newOffset = Math.min.apply(null, pendingPartitionTasks);
         if (newOffset !== task.offset) {

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -3,10 +3,12 @@
 
 const EventEmitter = require('events');
 const P = require('bluebird');
+const KafkaFactory = require('./kafka_factory');
 
 
 /** @const {number} the dafault queue size */
 const DEFAULT_SIZE = 100;
+const COMMIT_TIMEOUT = 100;
 
 
 /**
@@ -19,17 +21,22 @@ class TaskQueue extends EventEmitter {
      *
      * @param {Object} [options={}]
      * @param {number} [options.size=DEFAULT_SIZE] the maximum number of tasks in the queue
-     *
+     * @param {number} [options.commitTimeout=COMMIT_TIMEOUT] the maximum delay to commit the offset
      * @constructor
      */
     constructor(options) {
         super();
         options = options || {};
         this._max_size = options.size || DEFAULT_SIZE;
+        this._commit_timeout = options.commitTimeout || COMMIT_TIMEOUT;
         this._queue = [];
         this._waiting = [];
         this._consumers = [];
+        this._commitScheduled = false;
+        this._pendingCommits = new Map();
+
         this.on('task_completed', this._deferred.bind(this));
+        this.on('task_completed', this._commitOffsets.bind(this));
     }
 
     /**
@@ -52,8 +59,7 @@ class TaskQueue extends EventEmitter {
      * Enqueues a task on the queue. If the queue is full, the task will be placed on a waiting
      * list until enough tasks have been dequeued.
      *
-     * @param {Object} task the task to enqueue
-     * @param {number} task.id the message ID of the event
+     * @param {Task} task the task to enqueue
      * @param {HighLevelConsumer} task.consumer the Kafka consumer object used for offset commit
      * @param {Function} task.exec the promise to execute
      * @param {Function} task.catch the promise to execute in case the task's execution fails
@@ -71,22 +77,76 @@ class TaskQueue extends EventEmitter {
         return true;
     }
 
+    /**
+     * Finds the lowest offset that is safe to commit after some task finished.
+     *
+     * @param {Task} task just finished task
+     * @private
+     */
+    _updatePendingCommits(task) {
+        const current = this._pendingCommits.get(task.consumer)
+            && this._pendingCommits.get(task.consumer)[task.topic]
+            && this._pendingCommits.get(task.consumer)[task.topic][task.partition];
+        const pendingPartitionTasks = this._queue.filter((item) =>
+                item.consumerGroup === task.consumerGroup
+                && item.topic === task.topic
+                && item.partition === task.partition)
+        .map((item) => item.offset);
+        let newOffset = Math.min.apply(null, pendingPartitionTasks);
+        if (newOffset !== task.offset) {
+            // In case we have unfinished tasks with offsets lower then
+            // the current finished task offset, decrement it since this
+            // means the task with newOffset is still panding, but the one with
+            // a lower offset is already finished.
+            newOffset--;
+        }
+        if (current && current >= newOffset) {
+            // A higher offset is already scheduled for commit
+            return;
+        }
+
+        if (!this._pendingCommits.has(task.consumer)) {
+            this._pendingCommits.set(task.consumer, {});
+        }
+        this._pendingCommits.get(task.consumer)[task.topic] =
+            this._pendingCommits.get(task.consumer)[task.topic] || {};
+        this._pendingCommits.get(task.consumer)[task.topic][task.partition] = newOffset;
+    }
+
+    /**
+     * Begins the task execution
+     *
+     * @param {Task} task
+     * @private
+     */
     _start(task) {
         this._queue.push(task);
         task._p = P.try(() => {
             return task.exec().finally(() => {
+                this._updatePendingCommits(task);
                 this._queue = this._queue.filter((item) => item !== task);
                 this.emit('task_completed');
-            }).catch(task.catch);
-        }).then(task.consumer.commitAsync.bind(task.consumer));
+            }).catch(task.catch.bind(task));
+        });
     }
 
+    /**
+     * Defers the task execution, puts it into the waiting queue
+     *
+     * @param {Task} task
+     * @private
+     */
     _defer(task) {
         // put the task in the waiting queue and pause the consumers
         this._waiting.push(task);
         this._consumers.forEach((consumer) => consumer.pause());
     }
 
+    /**
+     * Begins execution of the deferred tasks
+     *
+     * @private
+     */
     _deferred() {
         // enqueue any outstanding tasks
         while (this._queue.length < this._max_size && this._waiting.length > 0) {
@@ -98,6 +158,29 @@ class TaskQueue extends EventEmitter {
         }
     }
 
+    /**
+     * Schedules a commit for pending commit requests
+     *
+     * @private
+     */
+    _commitOffsets() {
+        if (this._commitScheduled) {
+            return;
+        }
+
+        setTimeout(() => {
+            for (let entry of this._pendingCommits.entries()) {
+                const consumer = entry[0];
+                const topicsOffsets = entry[1];
+                Object.keys(topicsOffsets).forEach((topic) => {
+                    KafkaFactory.commit(consumer, topic, topicsOffsets[topic]);
+                });
+            }
+            this._pendingCommits = new Map();
+            this._commitScheduled = false;
+        }, this._commit_timeout);
+        this._commitScheduled = true;
+    }
 }
 
 


### PR DESCRIPTION
By default the `HighLevelConsumer` commits offsets of the most recent fetched messages. This is obviously incorrect as we want to commit the offset only after a task execution has been finished (either rejected, or successfully finished, or failed). However, if the service crashes while the task was executed, we don't want to commit the offset. 

As we have a `TaskQueue` now, we can track task execution, and commit proper offset when the task is finished (which is the minimal offset in the queue for the tasks consumerGroup, topic and partition).

As the commit itself is a heavy operation, we accumulate pending commits for some interval and commit all at once.

Also, introduced a simple `Task` class as an immutable (as immutable as it could be in JS) object to hold task properties and a couple of utility getters and functions.

cc @wikimedia/services 