### PR TITLE
Increase test coverage by limitting concurrency in tests

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -32,6 +32,7 @@ services:
                   uri: 127.0.0.1:2181
                   consume_dc: test_dc
                   produce_dc: test_dc
+                  concurrency: 2
                   templates:
                     simple_test_rule:
                       topic: simple_test_rule


### PR DESCRIPTION
Default `TaskQueue` concurrency is 100, so limit is never reached in tests, which means we don't cover some branches and functions. If we decrease test concurrency to 2, limit is reached and we get test coverage increase for free.

cc @wikimedia/services 