### PR TITLE
Supply triggered_by fields and provide x-triggered-by headers

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -88,9 +88,11 @@ services:
                               topic: '{{message.produce_to_topic}}'
                               uri: '{{message.meta.uri}}'
                               request_id: '{{message.meta.request_id}}'
+                              triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
                             message: 'test'
                           - meta:
                               topic: '{{message.produce_to_topic}}'
                               uri: '{{message.meta.uri}}'
                               request_id: '{{message.meta.request_id}}'
+                              triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
                             message: 'test'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -88,11 +88,11 @@ services:
                               topic: '{{message.produce_to_topic}}'
                               uri: '{{message.meta.uri}}'
                               request_id: '{{message.meta.request_id}}'
-                              triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
                             message: 'test'
+                            triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
                           - meta:
                               topic: '{{message.produce_to_topic}}'
                               uri: '{{message.meta.uri}}'
                               request_id: '{{message.meta.request_id}}'
-                              triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
                             message: 'test'
+                            triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -191,9 +191,9 @@ class RuleExecutor {
                 request_id: event.meta.request_id,
                 id: undefined, // will be filled later
                 dt: undefined, // will be filled later
-                domain: event.meta.domain,
-                triggered_by: utils.triggeredBy(retryEvent || event)
+                domain: event.meta.domain
             },
+            triggered_by: utils.triggeredBy(retryEvent || event),
             emitter_id: this._consumerId(),
             retries_left: retriesLeft === undefined ? this.rule.spec.retry_limit : retriesLeft,
             original_event: event,

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -4,6 +4,7 @@ const P = require('bluebird');
 const uuid = require('cassandra-uuid').TimeUuid;
 const TopicsNotExistError = require('wmf-kafka-node/lib/errors').TopicsNotExistError;
 const Task = require('./task');
+const utils = require('./utils');
 
 /**
  * A rule executor managing matching and execution of a single rule
@@ -63,24 +64,25 @@ class RuleExecutor {
         }
     }
 
-    _exec(event, statName, statDelayStartTime) {
+    _exec(origEvent, statName, statDelayStartTime, retryEvent) {
         const rule = this.rule;
 
-        this.log(`trace/${rule.name}`, { msg: 'Event message received', event: event });
+        this.log(`trace/${rule.name}`, { msg: 'Event message received', event: origEvent });
 
         // latency from the original event creation time to execution time
         this.hyper.metrics.endTiming([statName + '_delay'],
-            statDelayStartTime || new Date(event.meta.dt));
+            statDelayStartTime || new Date(origEvent.meta.dt));
 
         const startTime = Date.now();
         const expander = {
-            message: event,
-            match: rule.expand(event)
+            message: origEvent,
+            match: rule.expand(origEvent)
         };
         return P.each(rule.exec, (tpl) => {
             const request = tpl.expand(expander);
             request.headers = Object.assign(request.headers, {
-                'x-request-id': event.meta.request_id
+                'x-request-id': origEvent.meta.request_id,
+                'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
             });
             return this.hyper.request(request);
         })
@@ -152,10 +154,10 @@ class RuleExecutor {
 
                 return this.taskQueue.enqueue(new Task(consumer, message,
                     this._exec.bind(this, message.original_event,
-                        statName, new Date(message.meta.dt)),
+                        statName, new Date(message.meta.dt), message),
                     (e) => {
                         const retryMessage = this._constructRetryMessage(message.original_event,
-                            e, message.retries_left - 1);
+                            e, message.retries_left - 1, message);
                         if (this.rule.shouldRetry(e) && !this._isLimitExceeded(retryMessage)) {
                             return this._retry(retryMessage);
                         }
@@ -180,7 +182,7 @@ class RuleExecutor {
         return 'change-prop#' + this.rule.name;
     }
 
-    _constructRetryMessage(event, errorRes, retriesLeft) {
+    _constructRetryMessage(event, errorRes, retriesLeft, retryEvent) {
         return {
             meta: {
                 topic: this._retryTopicName(),
@@ -189,7 +191,8 @@ class RuleExecutor {
                 request_id: event.meta.request_id,
                 id: undefined, // will be filled later
                 dt: undefined, // will be filled later
-                domain: event.meta.domain
+                domain: event.meta.domain,
+                triggered_by: utils.triggeredBy(retryEvent || event)
             },
             emitter_id: this._consumerId(),
             retries_left: retriesLeft === undefined ? this.rule.spec.retry_limit : retriesLeft,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,9 +9,11 @@ const utils = {};
  * @returns {string}
  */
 utils.triggeredBy = (event) => {
-    return event.triggered_by ?
-    event.triggered_by + ',' + event.meta.topic + ':' + event.meta.uri :
-    event.meta.topic + ':' + event.meta.uri;
+    let prevTrigger = event.triggered_by || '';
+    if (prevTrigger) {
+        prevTrigger += ',';
+    }
+    return prevTrigger + event.meta.topic + ':' + event.meta.uri;
 };
 
 module.exports = utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,8 +9,8 @@ const utils = {};
  * @returns {string}
  */
 utils.triggeredBy = (event) => {
-    return event.meta.triggered_by ?
-    event.meta.triggered_by + ';' + event.meta.topic + ':' + event.meta.uri :
+    return event.triggered_by ?
+    event.triggered_by + ',' + event.meta.topic + ':' + event.meta.uri :
     event.meta.topic + ':' + event.meta.uri;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const utils = {};
+
+/**
+ * Computes the x-triggered-by header
+ *
+ * @param {Object} event the event
+ * @returns {string}
+ */
+utils.triggeredBy = (event) => {
+    return event.meta.triggered_by ?
+    event.meta.triggered_by + ';' + event.meta.topic + ':' + event.meta.uri :
+    event.meta.topic + ':' + event.meta.uri;
+};
+
+module.exports = utils;

--- a/sys/backlinks.js
+++ b/sys/backlinks.js
@@ -3,6 +3,7 @@
 const extend = require('extend');
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
+const utils = require('../lib/utils');
 
 const CONTINUE_TOPIC_NAME = 'change-prop.backlinks.continue';
 
@@ -60,7 +61,8 @@ class BackLinksProcessor {
                             uri: originalEvent.meta.uri,
                             request_id: originalEvent.meta.request_id,
                             domain: originalEvent.meta.domain,
-                            dt: originalEvent.meta.dt
+                            dt: originalEvent.meta.dt,
+                            triggered_by: utils.triggeredBy(originalEvent)
                         },
                         original_event: originalEvent,
                         continue: res.body.continue.blcontinue
@@ -83,7 +85,8 @@ class BackLinksProcessor {
                         uri: `https://${originalEvent.meta.domain}/wiki/${item.title}`,
                         request_id: originalEvent.meta.request_id,
                         domain: originalEvent.meta.domain,
-                        dt: originalEvent.meta.dt
+                        dt: originalEvent.meta.dt,
+                        triggered_by: utils.triggeredBy(originalEvent)
                     },
                     tags: [ 'change-prop', 'backlinks' ]
                 };

--- a/sys/backlinks.js
+++ b/sys/backlinks.js
@@ -61,9 +61,9 @@ class BackLinksProcessor {
                             uri: originalEvent.meta.uri,
                             request_id: originalEvent.meta.request_id,
                             domain: originalEvent.meta.domain,
-                            dt: originalEvent.meta.dt,
-                            triggered_by: utils.triggeredBy(originalEvent)
+                            dt: originalEvent.meta.dt
                         },
+                        triggered_by: utils.triggeredBy(originalEvent),
                         original_event: originalEvent,
                         continue: res.body.continue.blcontinue
                     }]
@@ -85,9 +85,9 @@ class BackLinksProcessor {
                         uri: `https://${originalEvent.meta.domain}/wiki/${item.title}`,
                         request_id: originalEvent.meta.request_id,
                         domain: originalEvent.meta.domain,
-                        dt: originalEvent.meta.dt,
-                        triggered_by: utils.triggeredBy(originalEvent)
+                        dt: originalEvent.meta.dt
                     },
+                    triggered_by: utils.triggeredBy(originalEvent),
                     tags: [ 'change-prop', 'backlinks' ]
                 };
             })

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -59,7 +59,8 @@ describe('Basic rule management', function() {
             reqheaders: {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'x-triggered-by': 'simple_test_rule:/sample/uri'
             }
         })
         .post('/', {
@@ -91,11 +92,15 @@ describe('Basic rule management', function() {
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).reply(500, {})
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
+        .reply(500, {})
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).reply(200, {});
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri')
+        .reply(200, {});
 
         return producer.sendAsync([{
             topic: 'test_dc.simple_test_rule',
@@ -117,11 +122,13 @@ describe('Basic rule management', function() {
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).reply(500, {})
+        })
+        .reply(500, {})
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).reply(200, {});
+        })
+        .reply(200, {});
         
         return kafkaFactory.newConsumer(kafkaFactory.newClient(),
             'change-prop.retry.simple_test_rule',
@@ -131,11 +138,14 @@ describe('Basic rule management', function() {
                 try {
                     const ajv = new Ajv();
                     const validate = ajv.compile(retrySchema);
-                    var valid = validate(JSON.parse(message.value));
+                    const msg = JSON.parse(message.value);
+                    const valid = validate(msg);
                     if (!valid) {
                         done(new assert.AssertionError({
                             message: ajv.errorsText(validate.errors)
                         }));
+                    } else if (msg.meta.triggered_by !== 'simple_test_rule:/sample/uri') {
+                            done(new Error('TriggeredBy should be equal to simple_test_rule:/sample/uri'));
                     } else {
                         done();
                     }
@@ -155,13 +165,27 @@ describe('Basic rule management', function() {
             reqheaders: {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
             }
         })
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).times(3).reply(500, {});
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
+        .reply(500, {})
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test'
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri')
+        .reply(500, {})
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test'
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri')
+        .reply(500, {});
 
         return producer.sendAsync([{
             topic: 'test_dc.simple_test_rule',
@@ -177,13 +201,16 @@ describe('Basic rule management', function() {
             reqheaders: {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'x-triggered-by': 'simple_test_rule:/sample/uri'
             }
         })
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).reply(404, {});
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
+        .reply(404, {});
 
         return producer.sendAsync([{
             topic: 'test_dc.simple_test_rule',
@@ -199,13 +226,16 @@ describe('Basic rule management', function() {
             reqheaders: {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'x-triggered-by': 'simple_test_rule:/sample/uri'
             }
         })
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).reply(200, {});
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
+        .reply(200, {});
 
         return producer.sendAsync([{
             topic: 'test_dc.simple_test_rule',
@@ -227,7 +257,9 @@ describe('Basic rule management', function() {
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
-        }).times(2).reply({});
+        })
+        .matchHeader('x-triggered-by', 'test_dc.kafka_producing_rule:/sample/uri;simple_test_rule:/sample/uri')
+        .times(2).reply({});
 
         return producer.sendAsync([{
             topic: 'test_dc.kafka_producing_rule',
@@ -259,7 +291,10 @@ describe('Basic rule management', function() {
                 backlinks: arrayWithLinks('Some_Page', 2)
             }
         })
-        .get('/api/rest_v1/page/html/Some_Page').times(2).reply(200)
+        .get('/api/rest_v1/page/html/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri;resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .times(2)
+        .reply(200)
         .post('/w/api.php', {
             format: 'json',
             action: 'query',
@@ -275,7 +310,10 @@ describe('Basic rule management', function() {
                 backlinks: arrayWithLinks('Some_Page', 1)
             }
         })
-        .get('/api/rest_v1/page/html/Some_Page').reply(200);
+        .get('/api/rest_v1/page/html/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri;resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .reply(200);
+
         return producer.sendAsync([{
             topic: 'test_dc.mediawiki.revision_create',
             messages: [

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -37,7 +37,7 @@ describe('Basic rule management', function() {
         })
         .then(() => changeProp.start())
         .then(() => preq.get({
-                uri: 'https://raw.githubusercontent.com/wikimedia/mediawiki-event-schemas/master/jsonschema/retry/1.yaml'
+                uri: 'https://raw.githubusercontent.com/wikimedia/mediawiki-event-schemas/master/jsonschema/change-prop/retry/1.yaml'
         }))
         .then((res) => retrySchema = yaml.safeLoad(res.body));
     });
@@ -99,7 +99,7 @@ describe('Basic rule management', function() {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
         })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri')
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
         .reply(200, {});
 
         return producer.sendAsync([{
@@ -144,7 +144,7 @@ describe('Basic rule management', function() {
                         done(new assert.AssertionError({
                             message: ajv.errorsText(validate.errors)
                         }));
-                    } else if (msg.meta.triggered_by !== 'simple_test_rule:/sample/uri') {
+                    } else if (msg.triggered_by !== 'simple_test_rule:/sample/uri') {
                             done(new Error('TriggeredBy should be equal to simple_test_rule:/sample/uri'));
                     } else {
                         done();
@@ -178,13 +178,13 @@ describe('Basic rule management', function() {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
         })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri')
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
         .reply(500, {})
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
         })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri;change-prop.retry.simple_test_rule:/sample/uri')
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
         .reply(500, {});
 
         return producer.sendAsync([{
@@ -258,7 +258,7 @@ describe('Basic rule management', function() {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
         })
-        .matchHeader('x-triggered-by', 'test_dc.kafka_producing_rule:/sample/uri;simple_test_rule:/sample/uri')
+        .matchHeader('x-triggered-by', 'test_dc.kafka_producing_rule:/sample/uri,simple_test_rule:/sample/uri')
         .times(2).reply({});
 
         return producer.sendAsync([{
@@ -292,7 +292,7 @@ describe('Basic rule management', function() {
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')
-        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri;resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
         .times(2)
         .reply(200)
         .post('/w/api.php', {
@@ -311,7 +311,7 @@ describe('Basic rule management', function() {
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')
-        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri;resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
         .reply(200);
 
         return producer.sendAsync([{

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -111,7 +111,6 @@ describe('RESTBase update rules', function() {
         })
         .get('/api/rest_v1/page/mobile-sections/Main%20Page')
         .query({ redirect: false })
-
         .reply(200, { });
 
         return producer.sendAsync([{

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -39,7 +39,8 @@ describe('RESTBase update rules', function() {
     it('Should update summary endpoint', () => {
         const mwAPI = nock('https://en.wikipedia.org', {
             reqheaders: {
-                'cache-control': 'no-cache'
+                'cache-control': 'no-cache',
+                'x-triggered-by': 'resource_change:https://en.wikipedia.org/api/rest_v1/page/html/Main%20Page'
             }
         })
         .get('/api/rest_v1/page/summary/Main%20Page')
@@ -71,7 +72,8 @@ describe('RESTBase update rules', function() {
     it('Should update definition endpoint', () => {
         const mwAPI = nock('https://en.wiktionary.org', {
             reqheaders: {
-                'cache-control': 'no-cache'
+                'cache-control': 'no-cache',
+                'x-triggered-by': 'resource_change:https://en.wiktionary.org/api/rest_v1/page/html/Main%20Page'
             }
         })
         .get('/api/rest_v1/page/definition/Main%20Page')
@@ -103,11 +105,13 @@ describe('RESTBase update rules', function() {
     it('Should update mobile apps endpoint', () => {
         const mwAPI = nock('https://en.wikipedia.org', {
             reqheaders: {
-                'cache-control': 'no-cache'
+                'cache-control': 'no-cache',
+                'x-triggered-by': 'resource_change:https://en.wikipedia.org/api/rest_v1/page/html/Main%20Page'
             }
         })
         .get('/api/rest_v1/page/mobile-sections/Main%20Page')
         .query({ redirect: false })
+
         .reply(200, { });
 
         return producer.sendAsync([{


### PR DESCRIPTION
We've decided to have an analogue of the XFF header in events, to prevent loops and for debugging purposes. This PR makes change-prop fill those properties.

Depends on https://gerrit.wikimedia.org/r/#/c/288918/

cc @wikimedia/services 