### PR TITLE
Various stability improvements

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -43,6 +43,8 @@ services:
                           - '50x'
                           - 400
                       match:
+                        meta:
+                          uri: '/sample/uri'
                         message: 'test'
                       exec:
                         method: post
@@ -84,7 +86,11 @@ services:
                         body:
                           - meta:
                               topic: '{{message.produce_to_topic}}'
+                              uri: '{{message.meta.uri}}'
+                              request_id: '{{message.meta.request_id}}'
                             message: 'test'
                           - meta:
                               topic: '{{message.produce_to_topic}}'
+                              uri: '{{message.meta.uri}}'
+                              request_id: '{{message.meta.request_id}}'
                             message: 'test'

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -101,10 +101,8 @@ class KafkaFactory {
      * @param {string} topic topic to commit offset for
      * @param {Object} offsets offset values to commit for partitions. Object keys
      *                         represent partitions, values - offsets.
-     * @param {Function} shouldResume a no-arg callback checking whether the consumer
-     *                                should be resumed after offsets have been committed
      */
-    static commit(consumer, topic, offsets, shouldResume) {
+    static commit(consumer, topic, offsets) {
         function setOffsets(values) {
             Object.keys(values).forEach((partition) => {
                 consumer.setOffset(topic, partition, values[partition]);
@@ -121,9 +119,6 @@ class KafkaFactory {
         return consumer.commitAsync(true)
         .then(() => {
             setOffsets(oldOffsets);
-            if (shouldResume()) {
-                consumer.resume();
-            }
         });
     }
 }

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -74,7 +74,7 @@ function _compileMatch(obj, result, name, fieldName) {
             result[fieldName] = obj;
             return `${name} === ${obj}`;
         }
-        if (obj[0] !== '/' || obj[obj.length - 1] !== '/') {
+        if (!/^\/.+\/[gimuy]{0,5}$/.test(obj)) {
             // not a regex, quote the string
             result[fieldName] = `'${obj}'`;
             return `${name} === '${obj}'`;

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -74,7 +74,7 @@ function _compileMatch(obj, result, name, fieldName) {
             result[fieldName] = obj;
             return `${name} === ${obj}`;
         }
-        if (obj[0] !== '/' && obj[obj.length - 1] !== '/') {
+        if (obj[0] !== '/' || obj[obj.length - 1] !== '/') {
             // not a regex, quote the string
             result[fieldName] = `'${obj}'`;
             return `${name} === '${obj}'`;

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -199,7 +199,6 @@ class RuleExecutor {
     }
 
     subscribe() {
-        const self = this;
         const rule = this.rule;
         const client = this.kafkaFactory.newClient();
         return this._setUpRetryTopic()
@@ -216,13 +215,13 @@ class RuleExecutor {
                         return;
                     }
 
-                    return self.taskQueue.enqueue(new Task(
+                    return this.taskQueue.enqueue(new Task(
                         consumer,
                         msg,
-                        self._exec.bind(self, message, statName),
+                        this._exec.bind(this, message, statName),
                         (e) => {
-                            if (self.rule.shouldRetry(e)) {
-                                return self._retry(self._constructRetryMessage(message, e));
+                            if (this.rule.shouldRetry(e)) {
+                                return this._retry(this._constructRetryMessage(message, e));
                             }
                         }
                     ));

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -50,12 +50,17 @@ class RuleExecutor {
     }
 
     _test(event) {
-        if (this.rule.test(event)) {
-            return true;
+        try {
+            if (this.rule.test(event)) {
+                return true;
+            }
+            // no match, drop the message
+            this.log(`debug/${this.rule.name}`, { msg: 'Dropping event message', event: event });
+            return false;
+        } catch (e) {
+            this.log(`error/${this.rule.name}`, e);
+            return false;
         }
-        // no match, drop the message
-        this.log(`debug/${this.rule.name}`, { msg: 'Dropping event message', event: event });
-        return false;
     }
 
     _exec(event, statName, statDelayStartTime) {
@@ -72,7 +77,13 @@ class RuleExecutor {
             message: event,
             match: rule.expand(event)
         };
-        return P.each(rule.exec, (tpl) => this.hyper.request(tpl.expand(expander)))
+        return P.each(rule.exec, (tpl) => {
+            const request = tpl.expand(expander);
+            request.headers = Object.assign(request.headers, {
+                'x-request-id': event.meta.request_id
+            });
+            return this.hyper.request(request);
+        })
         .finally(() => {
             this.hyper.metrics.endTiming([statName + '_exec'], startTime);
         });

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -20,7 +20,7 @@ const DEFAULT_SIZE = 100;
  * @const
  * @type {number}
  */
-const DEFAULT_COMMIT_TIMEOUT = 500;
+const DEFAULT_COMMIT_INTERVAL = 500;
 
 
 /**
@@ -33,15 +33,15 @@ class TaskQueue extends EventEmitter {
      *
      * @param {Object} [options={}]
      * @param {number} [options.size=DEFAULT_SIZE] the maximum number of tasks in the queue
-     * @param {number} [options.commit_timeout=COMMIT_TIMEOUT] the maximum delay to commit
-     *                                                        the offsets
+     * @param {number} [options.commit_interval=DEFAULT_COMMIT_INTERVAL] the maximum delay
+     *                                                                   to commit the offsets
      * @constructor
      */
     constructor(options) {
         super();
         options = options || {};
         this._max_size = options.size || DEFAULT_SIZE;
-        this._commitTimeout = options.commit_timeout || DEFAULT_COMMIT_TIMEOUT;
+        this._commitInterval = options.commit_interval || DEFAULT_COMMIT_INTERVAL;
         this._isPaused = false;
         this._queue = [];
         this._waiting = [];
@@ -200,7 +200,7 @@ class TaskQueue extends EventEmitter {
             });
             this._pendingCommits = new Map();
             this._commitScheduled = false;
-        }, this._commitTimeout);
+        }, this._commitInterval);
         this._commitScheduled = true;
     }
 }

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -7,7 +7,7 @@ const KafkaFactory = require('./kafka_factory');
 
 
 /**
- * The dafault queue size
+ * The default queue size
  *
  * @type {number}
  * @const
@@ -20,7 +20,7 @@ const DEFAULT_SIZE = 100;
  * @const
  * @type {number}
  */
-const COMMIT_TIMEOUT = 100;
+const DEFAULT_COMMIT_TIMEOUT = 500;
 
 
 /**
@@ -41,7 +41,7 @@ class TaskQueue extends EventEmitter {
         super();
         options = options || {};
         this._max_size = options.size || DEFAULT_SIZE;
-        this._commitTimeout = options.commit_timeout || COMMIT_TIMEOUT;
+        this._commitTimeout = options.commit_timeout || DEFAULT_COMMIT_TIMEOUT;
         this._isPaused = false;
         this._queue = [];
         this._waiting = [];
@@ -169,7 +169,8 @@ class TaskQueue extends EventEmitter {
         }
         // resume the consumers if the queue has empty slots
         if (this._queue.length < this._max_size) {
-            this._consumers.filter((cons) => cons.paused).forEach((cons) => cons.resume());
+            this._consumers.filter((cons) => cons.paused && !cons.isCommitting)
+            .forEach((cons) => cons.resume());
             this._isPaused = false;
         }
     }
@@ -187,8 +188,14 @@ class TaskQueue extends EventEmitter {
         setTimeout(() => {
             this._pendingCommits.forEach((topicsOffsets, consumer) => {
                 Object.keys(topicsOffsets).forEach((topic) => {
-                    KafkaFactory.commit(consumer, topic,
-                        topicsOffsets[topic], () => !this._isPaused);
+                    consumer.isCommitting = true;
+                    KafkaFactory.commit(consumer, topic, topicsOffsets[topic])
+                    .then(() => {
+                        consumer.isCommitting = false;
+                        if (!this._isPaused) {
+                            consumer.resume();
+                        }
+                    });
                 });
             });
             this._pendingCommits = new Map();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "change-propagation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Listens to events from Kafka and delivers them",
   "main": "server.js",
   "repository": {

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -58,7 +58,8 @@ describe('Basic rule management', function() {
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
-                'content-type': 'application/json'
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID
             }
         })
         .post('/', {
@@ -70,7 +71,9 @@ describe('Basic rule management', function() {
             topic: 'test_dc.simple_test_rule',
             messages: [
                 JSON.stringify(common.eventWithMessage('this_will_not_match')),
-                JSON.stringify(common.eventWithMessage('test')) ]
+                JSON.stringify(common.eventWithMessage('test')),
+                // The empty message should cause a failure in the match test
+                '{}' ]
         }])
         .delay(common.REQUEST_CHECK_DELAY)
         .then(() => service.done())
@@ -81,7 +84,8 @@ describe('Basic rule management', function() {
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
-                'content-type': 'application/json'
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID
             }
         })
         .post('/', {
@@ -106,7 +110,8 @@ describe('Basic rule management', function() {
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
-                'content-type': 'application/json'
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID
             }
         })
         .post('/', {
@@ -149,7 +154,8 @@ describe('Basic rule management', function() {
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
-                'content-type': 'application/json'
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID
             }
         })
         .post('/', {
@@ -170,7 +176,8 @@ describe('Basic rule management', function() {
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
-                'content-type': 'application/json'
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID
             }
         })
         .post('/', {
@@ -191,7 +198,8 @@ describe('Basic rule management', function() {
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
-                'content-type': 'application/json'
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID
             }
         })
         .post('/', {
@@ -212,7 +220,8 @@ describe('Basic rule management', function() {
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
-                'content-type': 'application/json'
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID
             }
         })
         .post('/', {

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -20,13 +20,15 @@ common.ALL_TOPICS = [
     'test_dc.change-prop.retry.resource_change'
 ];
 
+common.SAMPLE_REQUEST_ID = uuid.now().toString();
+
 common.eventWithProperties = (topic, props) => {
     const event = {
         meta: {
             topic: topic,
             schema_uri: 'schema/1',
             uri: '/sample/uri',
-            request_id: uuid.now(),
+            request_id: common.SAMPLE_REQUEST_ID,
             id: uuid.now(),
             dt: new Date().toISOString(),
             domain: 'en.wikipedia.org'


### PR DESCRIPTION
Today we've had some weird retry loop in change propagation again. While the root cause of the original issue is still not clear, while investigating it we've found several areas to improve the service:

1. In case there's an exception in the _test method, it crashes the service - fixed by wrapping in try-catch
2. The `x-request-id` header is not passed to RESTBase
3. There's a rase condition on consumer resuming. Fixed by adding an `isCommitting` flag
4. Increased commit interval to 500ms

cc @wikimedia/services 