### PR TITLE
Support named groups in regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ The rule can contain the following properties:
 - **match** An optional predicate for a message. The rule is executed only if all of the `match`
 properties were satisfied by the message. Properties could be nested objects, constants
 or a regex. Regex could contain capture groups and captured values will later be accessible
-in the `exec` part of the rule.
+in the `exec` part of the rule. Capture groups could be named, using the `(?<name>group)` syntax, then
+the captured value would be accessible under `match.property_name.capture_name` within the `exec` part.
+Named and unnamed captures can not be mixed together.
 - **match_not** An optional predicate which must not match for a rule to be executed. It doesn't capture values
 and doesn't make them accessible to the `exec` part of the rule.
 - **exec** An array of HTTP request templates, that will be executed sequentially if the rule matched.
@@ -52,7 +54,7 @@ convert it to HTCP purge and make an HTCP request:
       topic: resource_change
       match:
         meta:
-          uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(.+)$/'
+          uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(?<rest>.+)$/'
         tags:
           - restbase
       exec:
@@ -60,7 +62,7 @@ convert it to HTCP purge and make an HTCP request:
         uri: '/sys/purge/'
         body:
           - meta:
-              uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri[1]}}'
+              uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri.rest}}'
 
 ```
 

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -49,7 +49,7 @@ services:
                           - '5xx'
                       match:
                         meta:
-                          uri: '/^(https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/([^/]+)$/'
+                          uri: '/^(:<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(:<title>[^/]+)$/'
                         tags:
                           - restbase
                       match_not:
@@ -58,7 +58,7 @@ services:
                       exec:
                         method: get
                         # Don't encode title since it should be already encoded
-                        uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri[2]}}'
+                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
                         query:
                           redirect: false
                         headers:
@@ -75,14 +75,14 @@ services:
                         meta:
                           # These URIs are coming from RESTBase, so we know that article titles will be normalized
                           # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
-                          uri: '/^(https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/((?:(?!%3a|%3A).)+)$/'
+                          uri: '/^(:<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(:<title>(?:(?!%3a|%3A).)+)$/'
                           domain: '/^en.wiktionary.org$/'
                         tags:
                           - restbase
                       exec:
                         method: get
                         # Don't encode title since it should be already encoded
-                        uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri[2]}}'
+                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri.title}}'
                         query:
                           redirect: false
                         headers:
@@ -97,10 +97,10 @@ services:
                           - '5xx'
                       match:
                         meta:
-                          uri: '/^(https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/([^/]+)$/'
+                          uri: '/^(:<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(:<title>[^/]+)$/'
                       exec:
                         method: get
-                        uri: '{{match.meta.uri[1]}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri[2]}}'
+                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
                         query:
                           redirect: false
                         headers:
@@ -110,7 +110,7 @@ services:
                       topic: resource_change
                       match:
                         meta:
-                          uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(.+)$/'
+                          uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(:<title>.+)$/'
                         tags:
                           - restbase
                       exec:
@@ -118,4 +118,4 @@ services:
                         uri: '/sys/purge/'
                         body:
                           - meta:
-                              uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri[1]}}'
+                              uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri.title}}'

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -49,7 +49,7 @@ services:
                           - '5xx'
                       match:
                         meta:
-                          uri: '/^(:<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(:<title>[^/]+)$/'
+                          uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
                         tags:
                           - restbase
                       match_not:
@@ -75,7 +75,7 @@ services:
                         meta:
                           # These URIs are coming from RESTBase, so we know that article titles will be normalized
                           # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
-                          uri: '/^(:<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(:<title>(?:(?!%3a|%3A).)+)$/'
+                          uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A).)+)$/'
                           domain: '/^en.wiktionary.org$/'
                         tags:
                           - restbase
@@ -97,7 +97,7 @@ services:
                           - '5xx'
                       match:
                         meta:
-                          uri: '/^(:<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(:<title>[^/]+)$/'
+                          uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
                       exec:
                         method: get
                         uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
@@ -110,7 +110,7 @@ services:
                       topic: resource_change
                       match:
                         meta:
-                          uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(:<title>.+)$/'
+                          uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(?<title>.+)$/'
                         tags:
                           - restbase
                       exec:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -70,11 +70,11 @@ services:
                       topic: resource_change
                       match:
                         meta:
-                          uri: '/https:\/\/[^\/]+\/wiki\/(.+)/'
+                          uri: '/https:\/\/[^\/]+\/wiki\/(:<title>.+)/'
                         tags: [ 'change-prop', 'backlinks' ]
                       exec:
                         method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{match.meta.uri[1]}'
+                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
                         headers:
                           cache-control: no-cache
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -70,7 +70,7 @@ services:
                       topic: resource_change
                       match:
                         meta:
-                          uri: '/https:\/\/[^\/]+\/wiki\/(:<title>.+)/'
+                          uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
                         tags: [ 'change-prop', 'backlinks' ]
                       exec:
                         method: get

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -66,6 +66,12 @@ function _compileNamedRegex(obj, result, name, fieldName) {
         captureNames.push(name);
         return '(';
     });
+    const numGroups = (new RegExp(normalRegex.toString() + '|')).exec('').length - 1;
+
+    if (captureNames.length && captureNames.length !== numGroups) {
+        throw new Error('Invalid match regex. ' +
+            'Mixing named and unnamed capture groups are not supported. Regex: ' + obj);
+    }
 
     if (!captureNames.length) {
         // No named captures

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -62,7 +62,7 @@ function _compileArrayMatch(obj, result, name) {
 
 function _compileNamedRegex(obj, result, name, fieldName) {
     const captureNames = [];
-    const normalRegex = obj.replace(/\(:<(\w+)>/g, (_, name) => {
+    const normalRegex = obj.replace(/\(\?<(\w+)>/g, (_, name) => {
         captureNames.push(name);
         return '(';
     });

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -48,7 +48,6 @@ function _compileRetryCondition(retryDefinition) {
 function _getMatchObjCode(obj) {
     if (obj.constructor === Object) {
         return '{' + Object.keys(obj).map((key) => {
-            const field = obj[key];
             return key + ': ' + _getMatchObjCode(obj[key]);
         }).join(', ') + '}';
     }
@@ -59,6 +58,27 @@ function _compileArrayMatch(obj, result, name) {
     const itemsCheck = obj.map((item, index) =>
         `${name}.find((item) => ${_compileMatch(item, {}, 'item', index)})`).join(' && ');
     return `Array.isArray(${name})` + (itemsCheck.length ? (' && ' + itemsCheck) : '');
+}
+
+function _compileNamedRegex(obj, result, name, fieldName) {
+    const captureNames = [];
+    const normalRegex = obj.replace(/\(:<(\w+)>/g, (_, name) => {
+        captureNames.push(name);
+        return '(';
+    });
+
+    if (!captureNames.length) {
+        // No named captures
+        result[fieldName] = `${normalRegex}.exec(${name})`;
+    } else {
+        let code = `(() => { const execRes = ${normalRegex}.exec(${name}); const res = {}; `;
+        captureNames.forEach((captureName, index) => {
+            code += `res['${captureName}'] = execRes[${index + 1}]; `;
+        });
+        result[fieldName] = code + 'return res; })()';
+    }
+
+    return `${normalRegex}.test(${name})`;
 }
 
 function _compileMatch(obj, result, name, fieldName) {
@@ -80,8 +100,7 @@ function _compileMatch(obj, result, name, fieldName) {
             return `${name} === '${obj}'`;
         }
         // it's a regex, we have to the test the arg
-        result[fieldName] = `${obj}.exec(${name})`;
-        return `${obj}.test(${name})`;
+        return _compileNamedRegex(obj, result, name, fieldName);
     }
 
     // this is an object, we need to split it into components

--- a/test/feature/rule.js
+++ b/test/feature/rule.js
@@ -162,6 +162,16 @@ describe('Rule', function() {
             assert.deepEqual(exp.meta.uri, /\/fake\/([^\/]+)/.exec(msg.meta.uri));
         });
 
+        it('expansion with named groups', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/{match.meta.uri.element}/c'},
+                match: { meta: { uri: "/\\/fake\\/(:<element>[^\\/]+)/" }, number: 1 }
+            });
+            var exp = r.expand(msg);
+            assert.deepEqual(exp.meta.uri, { element: 'uri' });
+        });
+
     });
 
 });

--- a/test/feature/rule.js
+++ b/test/feature/rule.js
@@ -172,6 +172,20 @@ describe('Rule', function() {
             assert.deepEqual(exp.meta.uri, { element: 'uri' });
         });
 
+        it('checks for named and unnamed groups mixing', function() {
+            try {
+                var r = new Rule('rule', {
+                    topic: 'nono',
+                    exec: {uri: 'a/{match.meta.uri.element}/c'},
+                    match: { meta: { uri: "/\\/(\w+)\\/(?<element>[^\\/]+)/" }, number: 1 }
+                });
+                throw new Error('Error must be thrown');
+            } catch (e) {
+                assert.deepEqual(e.message,
+                    'Invalid match regex. Mixing named and unnamed capture groups are not supported. Regex: /\\/(w+)\\/(?<element>[^\\/]+)/');
+            }
+        });
+
     });
 
 });

--- a/test/feature/rule.js
+++ b/test/feature/rule.js
@@ -166,7 +166,7 @@ describe('Rule', function() {
             var r = new Rule('rule', {
                 topic: 'nono',
                 exec: {uri: 'a/{match.meta.uri.element}/c'},
-                match: { meta: { uri: "/\\/fake\\/(:<element>[^\\/]+)/" }, number: 1 }
+                match: { meta: { uri: "/\\/fake\\/(?<element>[^\\/]+)/" }, number: 1 }
             });
             var exp = r.expand(msg);
             assert.deepEqual(exp.meta.uri, { element: 'uri' });


### PR DESCRIPTION
Just a bit of syntactic sugar - when the match elements are taken from a regex, we need to reference them via indexes, which is not really convenient. Instead, support naming capture groups with the following syntax: `(?<name>group_regex)` and reference them by name.

Named groups cannot be mixed with unnamed groups.

cc @wikimedia/services 