### PR TITLE
File transclusions processing

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -34,6 +34,8 @@ services:
                         uri: 'https://{{message.meta.domain}}/w/api.php'
                         headers:
                           host: '{{message.meta.domain}}'
+                        body:
+                          formatversion: 2
           /sys/queue:
             x-modules:
               - path: sys/kafka.js
@@ -233,3 +235,5 @@ services:
                         uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
                         headers:
                           cache-control: no-cache
+                        query:
+                          redirect: false

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -27,7 +27,7 @@ services:
                   port: 4321
           /sys/links:
             x-modules:
-              - path: sys/backlinks.js
+              - path: sys/dep_updates.js
                 options:
                   templates:
                     mw_api:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -221,3 +221,15 @@ services:
                         method: 'post'
                         uri: '/sys/links/transcludes/{{message.page_title}}'
                         body: '{{globals.message}}'
+
+                    transclusion_updates:
+                      topic: resource_change
+                      match:
+                        meta:
+                          uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+                        tags: [ 'change-prop', 'transcludes' ]
+                      exec:
+                        method: get
+                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                        headers:
+                          cache-control: no-cache

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -214,3 +214,10 @@ services:
                             if-unmodified-since: '{{date(message.meta.dt)}}'
                           query:
                             redirect: false
+
+                    transclusion_update:
+                      topic: mediawiki.revision_create
+                      exec:
+                        method: 'post'
+                        uri: '/sys/links/transcludes/{{message.page_title}}'
+                        body: '{{globals.message}}'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -28,6 +28,8 @@ services:
                         uri: 'https://{{message.meta.domain}}/w/api.php'
                         headers:
                           host: '{{message.meta.domain}}'
+                        body:
+                          formatversion: 2
           /sys/queue:
             x-modules:
               - path: sys/kafka.js

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -21,7 +21,7 @@ services:
         paths:
           /sys/links:
             x-modules:
-              - path: sys/backlinks.js
+              - path: sys/dep_updates.js
                 options:
                   templates:
                     mw_api:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "service-runner": "^1.3.0",
     "wmf-kafka-node": "^0.1.3",
     "json-stable-stringify": "^1.0.1",
-    "htcp-purge": "^0.1.2"
+    "htcp-purge": "^0.1.2",
+    "mediawiki-title": "^0.4.2"
   },
   "devDependencies": {
     "istanbul": "^0.4.3",

--- a/sys/backlinks.js
+++ b/sys/backlinks.js
@@ -4,12 +4,15 @@ const extend = require('extend');
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
 const utils = require('../lib/utils');
+const Title = require('mediawiki-title').Title;
 
-const CONTINUE_TOPIC_NAME = 'change-prop.backlinks.continue';
+const BACKLINKS_CONTINUE_TOPIC_NAME = 'change-prop.backlinks.continue';
+const TRANSCLUDES_CONTINUE_TOPIC_NAME = 'change-prop.transcludes.continue';
 
 class BackLinksProcessor {
     constructor(options) {
         this.options = options;
+        this.siteInfoCache = {};
         this.backLinksRequest = new Template(extend(true, {}, options.templates.mw_api, {
             method: 'post',
             body: {
@@ -22,6 +25,39 @@ class BackLinksProcessor {
                 bllimit: 500
             }
         }));
+        this.imageLinksRequest = new Template(extend(true, {}, options.templates.mw_api, {
+            method: 'post',
+            body: {
+                format: 'json',
+                action: 'query',
+                list: 'imageusage',
+                iutitle: '{{request.params.title}}',
+                iucontinue: '{{message.continue}}',
+                iulimit: 500
+            }
+        }));
+        this.transcludeInRequest = new Template(extend(true, {}, options.templates.mw_api, {
+            method: 'post',
+            body: {
+                format: 'json',
+                action: 'query',
+                prop: 'transcludedin',
+                tiprop: 'title',
+                tishow: '!redirect',
+                titles: '{{request.params.title}}',
+                ticontinue: '{{message.continue}}',
+                tilimit: 500
+            }
+        }));
+        this.siteInfoRequest = new Template(extend(true, {}, options.templates.mw_api, {
+            method: 'post',
+            body: {
+                format: 'json',
+                action: 'query',
+                meta: 'siteinfo',
+                siprop: 'general|namespaces|namespacealiases'
+            }
+        }));
     }
 
     setup(hyper) {
@@ -29,11 +65,21 @@ class BackLinksProcessor {
             uri: '/sys/queue/subscriptions',
             body: {
                 backlinks_continue: {
-                    topic: CONTINUE_TOPIC_NAME,
+                    topic: BACKLINKS_CONTINUE_TOPIC_NAME,
                     exec: [
                         {
                             method: 'post',
                             uri: '/sys/links/backlinks/{message.original_event.title}',
+                            body: '{{globals.message}}'
+                        }
+                    ]
+                },
+                transclusions_continue: {
+                    topic: TRANSCLUDES_CONTINUE_TOPIC_NAME,
+                    exec: [
+                        {
+                            method: 'post',
+                            uri: '/sys/links/transcludes/{message.original_event.page_title}',
                             body: '{{globals.message}}'
                         }
                     ]
@@ -50,13 +96,14 @@ class BackLinksProcessor {
         return hyper.post(this.backLinksRequest.expand(context))
         .then((res) => {
             const originalEvent = req.body.original_event || req.body;
-            let actions = this._sendResourceChanges(hyper, res.body.query.backlinks, originalEvent);
+            let actions = this._sendResourceChanges(hyper, res.body.query.backlinks,
+                originalEvent, 'backlinks');
             if (res.body.continue) {
                 actions = actions.then(() => hyper.post({
                     uri: '/sys/queue/events',
                     body: [{
                         meta: {
-                            topic: CONTINUE_TOPIC_NAME,
+                            topic: BACKLINKS_CONTINUE_TOPIC_NAME,
                             schema_uri: 'continue/1',
                             uri: originalEvent.meta.uri,
                             request_id: originalEvent.meta.request_id,
@@ -73,7 +120,67 @@ class BackLinksProcessor {
         });
     }
 
-    _sendResourceChanges(hyper, items, originalEvent) {
+    processTranscludes(hyper, req) {
+        const message = req.body;
+        const context = {
+            request: req,
+            message: message
+        };
+
+        return this._getSiteInfo(hyper, message)
+        .then((siteInfo) => {
+            const title = Title.newFromText(message.page_title, siteInfo);
+            let linksRequest;
+            let continuationName;
+            let resultGetter;
+
+            if (title.getNamespace().isFile()) {
+                continuationName = 'iucontinue';
+                resultGetter = (res) => {
+                    return res.body.query.imageusage;
+                };
+                linksRequest = this.imageLinksRequest.expand(context);
+            } else {
+                continuationName = 'ticontinue';
+                resultGetter = (res) => {
+                    return res.body.query.pages[Object.keys(res.body.query.pages)[0]].transcludedin;
+                };
+                linksRequest = this.transcludeInRequest.expand(context);
+            }
+            return hyper.post(linksRequest)
+            .then((res) => {
+                const originalEvent = req.body.original_event || req.body;
+                const titles = resultGetter(res).map((item) => {
+                    return {
+                        title: Title.newFromText(item.title, siteInfo).getPrefixedDBKey()
+                    };
+                });
+                let actions = this._sendResourceChanges(hyper, titles,
+                    originalEvent, 'transcludes');
+                if (res.body.continue) {
+                    actions = actions.then(() => hyper.post({
+                        uri: '/sys/queue/events',
+                        body: [{
+                            meta: {
+                                topic: TRANSCLUDES_CONTINUE_TOPIC_NAME,
+                                schema_uri: 'continue/1',
+                                uri: originalEvent.meta.uri,
+                                request_id: originalEvent.meta.request_id,
+                                domain: originalEvent.meta.domain,
+                                dt: originalEvent.meta.dt
+                            },
+                            triggered_by: utils.triggeredBy(originalEvent),
+                            original_event: originalEvent,
+                            continue: res.body.continue[continuationName]
+                        }]
+                    }));
+                }
+                return actions.thenReturn({ status: 200 });
+            });
+        });
+    }
+
+    _sendResourceChanges(hyper, items, originalEvent, tag) {
         return hyper.post({
             uri: '/sys/queue/events',
             body: items.map((item) => {
@@ -88,10 +195,31 @@ class BackLinksProcessor {
                         dt: originalEvent.meta.dt
                     },
                     triggered_by: utils.triggeredBy(originalEvent),
-                    tags: [ 'change-prop', 'backlinks' ]
+                    tags: [ 'change-prop', tag ]
                 };
             })
         });
+    }
+
+    _getSiteInfo(hyper, message) {
+        const domain = message.meta.domain;
+        if (!this.siteInfoCache[domain]) {
+            this.siteInfoCache[domain] = hyper.post(this.siteInfoRequest.expand({
+                message: message
+            }))
+            .then((res) => {
+                return {
+                    general: {
+                        lang: res.body.query.general.lang,
+                        legaltitlechars: res.body.query.general.legaltitlechars,
+                        case: res.body.query.general.case
+                    },
+                    namespaces: res.body.query.namespaces,
+                    namespacealiases: res.body.query.namespacealiases
+                };
+            });
+        }
+        return this.siteInfoCache[domain];
     }
 }
 
@@ -111,11 +239,18 @@ module.exports = (options) => {
                         summary: 'set up the kafka listener',
                         operationId: 'process_backlinks'
                     }
+                },
+                '/transcludes/{title}': {
+                    post: {
+                        summary: 'check if the page is transcluded somewhere and update',
+                        operationId: 'process_transcludes'
+                    }
                 }
             }
         },
         operations: {
             process_backlinks: processor.processBackLinks.bind(processor),
+            process_transcludes: processor.processTranscludes.bind(processor),
             setup: processor.setup.bind(processor)
         },
         resources: [{

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -75,7 +75,7 @@ function createTranscludeInTemplate(options) {
     };
 }
 
-class BackLinksProcessor {
+class DependencyProcessor {
     constructor(options) {
         this.options = options;
         this.siteInfoCache = {};
@@ -237,7 +237,7 @@ class BackLinksProcessor {
 }
 
 module.exports = (options) => {
-    const processor = new BackLinksProcessor(options);
+    const processor = new DependencyProcessor(options);
     return {
         spec: {
             paths: {

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -22,6 +22,7 @@ describe('Basic rule management', function() {
     let producer;
     let retrySchema;
     let errorSchema;
+    let siteInfoResponse;
 
     before(function() {
         // Setting up might tike some tome, so disable the timeout
@@ -46,20 +47,20 @@ describe('Basic rule management', function() {
         .then(() => preq.get({
                 uri: 'https://raw.githubusercontent.com/wikimedia/mediawiki-event-schemas/master/jsonschema/error/1.yaml'
         }))
-        .then((res) => errorSchema = yaml.safeLoad(res.body));
-    });
-
-    function arrayWithLinks(link, num) {
-        const result = [];
-        for(let idx = 0; idx < num; idx++) {
-            result.push({
-                pageid: 1,
-                ns: 0,
-                title: link
+        .then((res) => errorSchema = yaml.safeLoad(res.body))
+        .then(() => {
+            preq.post({
+                uri: 'https://en.wikipedia.org/w/api.php',
+                body: {
+                    format: 'json',
+                    action: 'query',
+                    meta: 'siteinfo',
+                    siprop: 'general|namespaces|namespacealiases'
+                }
             });
-        }
-        return result;
-    }
+        })
+        .then((res) => siteInfoResponse = res)
+    });
 
     it('Should call simple executor', () => {
         const service = nock('http://mock.com', {
@@ -317,6 +318,13 @@ describe('Basic rule management', function() {
         .post('/w/api.php', {
             format: 'json',
             action: 'query',
+            meta: 'siteinfo',
+            siprop: 'general|namespaces|namespacealiases'
+        })
+        .reply(200, common.EN_SITE_INFO_RESPONSE)
+        .post('/w/api.php', {
+            format: 'json',
+            action: 'query',
             list: 'backlinks',
             bltitle: 'Main_Page',
             blfilterredir: 'nonredirects',
@@ -328,7 +336,7 @@ describe('Basic rule management', function() {
                 continue: '-||'
             },
             query: {
-                backlinks: arrayWithLinks('Some_Page', 2)
+                backlinks: common.arrayWithLinks('Some_Page', 2)
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')
@@ -347,7 +355,7 @@ describe('Basic rule management', function() {
         .reply(200, {
             batchcomplete: '',
             query: {
-                backlinks: arrayWithLinks('Some_Page', 1)
+                backlinks: common.arrayWithLinks('Some_Page', 1)
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -328,7 +328,9 @@ describe('Basic rule management', function() {
             list: 'backlinks',
             bltitle: 'Main_Page',
             blfilterredir: 'nonredirects',
-            bllimit: '500' })
+            bllimit: '500',
+            formatversion: '2'
+        })
         .reply(200, {
             batchcomplete: '',
             continue: {
@@ -350,7 +352,8 @@ describe('Basic rule management', function() {
             bltitle: 'Main_Page',
             blfilterredir: 'nonredirects',
             bllimit: '500',
-            blcontinue: '1|2272'
+            blcontinue: '1|2272',
+            formatversion: '2'
         })
         .reply(200, {
             batchcomplete: '',

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -420,7 +420,9 @@ describe('RESTBase update rules', function() {
             action: 'query',
             list: 'imageusage',
             iutitle: 'File:Test.jpg',
-            iulimit: '500' })
+            iulimit: '500',
+            formatversion: '2'
+        })
         .reply(200, {
             batchcomplete: '',
             continue: {
@@ -432,6 +434,7 @@ describe('RESTBase update rules', function() {
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')
+        .query({redirect: false})
         .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
         .times(2)
         .reply(200)
@@ -441,7 +444,9 @@ describe('RESTBase update rules', function() {
             list: 'imageusage',
             iutitle: 'File:Test.jpg',
             iulimit: '500',
-            iucontinue: '1|2272'})
+            iucontinue: '1|2272',
+            formatversion: '2'
+        })
         .reply(200, {
             batchcomplete: '',
             query: {
@@ -449,6 +454,7 @@ describe('RESTBase update rules', function() {
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')
+        .query({redirect: false})
         .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
         .reply(200);
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -405,6 +405,64 @@ describe('RESTBase update rules', function() {
         .finally(() => nock.cleanAll());
     });
 
+
+    it('Should rerender image usages on file update', () => {
+        const mwAPI = nock('https://en.wikipedia.org')
+        .post('/w/api.php', {
+            format: 'json',
+            action: 'query',
+            meta: 'siteinfo',
+            siprop: 'general|namespaces|namespacealiases'
+        })
+        .reply(200, common.EN_SITE_INFO_RESPONSE)
+        .post('/w/api.php', {
+            format: 'json',
+            action: 'query',
+            list: 'imageusage',
+            iutitle: 'File:Test.jpg',
+            iulimit: '500' })
+        .reply(200, {
+            batchcomplete: '',
+            continue: {
+                iucontinue: '1|2272',
+                continue: '-||'
+            },
+            query: {
+                imageusage: common.arrayWithLinks('Some_Page', 2)
+            }
+        })
+        .get('/api/rest_v1/page/html/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .times(2)
+        .reply(200)
+        .post('/w/api.php', {
+            format: 'json',
+            action: 'query',
+            list: 'imageusage',
+            iutitle: 'File:Test.jpg',
+            iulimit: '500',
+            iucontinue: '1|2272'})
+        .reply(200, {
+            batchcomplete: '',
+            query: {
+                imageusage: common.arrayWithLinks('Some_Page', 1)
+            }
+        })
+        .get('/api/rest_v1/page/html/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .reply(200);
+
+        return producer.sendAsync([{
+            topic: 'test_dc.mediawiki.revision_create',
+            messages: [
+                JSON.stringify(common.eventWithProperties('mediawiki.revision_create', { page_title: 'File:Test.jpg' }))
+            ]
+        }])
+        .delay(common.REQUEST_CHECK_DELAY)
+        .then(() => mwAPI.done())
+        .finally(() => nock.cleanAll());
+    });
+
     it('Should purge caches on resource_change coming from RESTBase', (done) => {
         var udpServer = dgram.createSocket('udp4');
         let closed = false;

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -15,7 +15,7 @@ var ChangeProp = function(configPath) {
     this._config.num_workers = 0;
     this._config.logging = {
         name: 'change-prop',
-        level: 'error',
+        level: 'fatal',
         streams: [{ type: 'stdout'}]
     };
     this._runner = new ServiceRunner();

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -15,7 +15,7 @@ var ChangeProp = function(configPath) {
     this._config.num_workers = 0;
     this._config.logging = {
         name: 'change-prop',
-        level: 'fatal',
+        level: 'error',
         streams: [{ type: 'stdout'}]
     };
     this._runner = new ServiceRunner();

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -16,6 +16,8 @@ common.ALL_TOPICS = [
     'test_dc.change-prop.retry.mediawiki.revision_create',
     'test_dc.change-prop.backlinks.continue',
     'test_dc.change-prop.retry.change-prop.backlinks.continue',
+    'test_dc.change-prop.transcludes.continue',
+    'test_dc.change-prop.retry.change-prop.transcludes.continue',
     'test_dc.resource_change',
     'test_dc.change-prop.retry.resource_change',
     'test_dc.change-prop.error',

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -55,4 +55,38 @@ common.eventWithMessage = (message) => {
     return common.eventWithProperties('simple_test_rule', { message: message });
 };
 
+common.arrayWithLinks = function(link, num) {
+    const result = [];
+    for(let idx = 0; idx < num; idx++) {
+        result.push({
+            pageid: 1,
+            ns: 0,
+            title: link
+        });
+    }
+    return result;
+};
+
+common.EN_SITE_INFO_RESPONSE = {
+    "query": {
+        "general": {
+            "legaltitlechars": " %!\"$&'()*,\\-.\\/0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+",
+            "case": "first-letter",
+            "lang": "en"
+        },
+        "namespaces": {
+            "-2": {"id": -2, "case": "first-letter", "canonical": "Media", "*": "Media"},
+            "-1": {"id": -1, "case": "first-letter", "canonical": "Special", "*": "Special"},
+            "0": {"id": 0, "case": "first-letter", "content": "", "*": ""},
+            "1": {"id": 1, "case": "first-letter", "subpages": "", "canonical": "Talk", "*": "Talk"},
+            "2": {"id": 2, "case": "first-letter", "subpages": "", "canonical": "User", "*": "User"},
+            "3": {"id": 3, "case": "first-letter", "subpages": "", "canonical": "User talk", "*": "User talk"},
+            "4": {"id": 4, "case": "first-letter", "subpages": "", "canonical": "Project", "*": "Wikipedia"},
+            "5": {"id": 5, "case": "first-letter", "subpages": "", "canonical": "Project talk", "*": "Wikipedia talk"},
+            "6": {"id": 6, "case": "first-letter", "canonical": "File", "*": "File"},
+            "7": {"id": 7, "case": "first-letter", "subpages": "", "canonical": "File talk", "*": "File talk"}
+        }
+    }
+};
+
 module.exports = common;


### PR DESCRIPTION
There're two types of dependency updates left in the update jobs:
 - File transclusions
 - Other transclusions

The former is less high-volume (at least it's unlikely that one file would be used in tens of thousands of pages), so let's start examining the continuation module by porting only file transclusions.  Right now it's a direct port of what RBUpdateJob is doing, but there's a couple of enhancements we might wanna do later - decide what to do with redirect pages for example.

In order for this to work we need to set up a new topic for transcludes continuation.

Tested with vagrant, it seems to work, but proper labs testing is required.
Also, it's not clear what would happen for files on 'commons' used in the wikis, I obviously cannot test it in vagrant.

cc @wikimedia/services 