### PR TITLE
Added test for redirects, added status monitoring

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -56,6 +56,16 @@ services:
                           test_field_name: test_field_value
                           derived_field: '{{message.message}}'
 
+                    redirect_testing_rule:
+                      topic: simple_test_rule
+                      match:
+                        meta:
+                          uri: '/sample/uri'
+                        message: 'redirect'
+                      exec:
+                        method: get
+                        uri: 'http://mock.com/will_redirect'
+
                     process_redlinks:
                       topic: mediawiki.revision_create
                       retry_limit: 0

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -37,7 +37,7 @@ class RuleExecutor {
                     rule: { name: ruleName, topic },
                     msg: `Listening to ${topicList[0]}`
                 });
-                this._notifySubscribed(topic)
+                this._notifySubscribed(topic);
             } else {
                 this.log(`info/subscription/${ruleName}`, {
                     rule: { name: ruleName, topic },

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -85,7 +85,18 @@ class RuleExecutor {
                 'x-request-id': origEvent.meta.request_id,
                 'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
             });
-            return this.hyper.request(request);
+            return this.hyper.request(request)
+            .tap((res) => {
+                if (res.status === 301) {
+                    // As we don't follow redirects, and we must always use normalized titles,
+                    // receiving 301 indicates some error. Log a warning.
+                    this.log(`warn/${this.rule.name}`, {
+                        message: '301 redirect received, used a non-normalized title',
+                        rule: this.rule.name,
+                        event: origEvent
+                    });
+                }
+            });
         })
         .finally(() => {
             this.hyper.metrics.endTiming([statName + '_exec'], startTime);
@@ -121,6 +132,21 @@ class RuleExecutor {
     }
 
     /**
+     * Notify master what this worker is doing for debugging purposes if it fails
+     * In production normally one worker will succeed subscribing only to one rule,
+     * so this will emit the only rule the worker is processing
+     *
+     * @param {string} ruleName the name of the rule this worker is processing.
+     * @private
+     */
+    _notifySubscribed(ruleName) {
+        process.emit('service_status', {
+            type: 'subscription',
+            rule: ruleName
+        });
+    }
+
+    /**
      * Set's up a consumer a retry queue
      *
      * @private
@@ -132,6 +158,7 @@ class RuleExecutor {
             retryTopicName,
             `change-prop-${retryTopicName}-${this.rule.name}`)
         .then((consumer) => {
+            this._notifySubscribed(this.rule.name + '-retry');
             this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
             this.retryConsumer.on('message', (msg) => {
                 const statName = this.hyper.metrics.normalizeName(this.rule.name + '_retry');
@@ -257,6 +284,7 @@ class RuleExecutor {
         .then(() => {
             return this.kafkaFactory.newConsumer(client, rule.topic, `change-prop-${rule.name}`)
             .then((consumer) => {
+                this._notifySubscribed(this.rule.name);
                 this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
                 this.taskQueue.addConsumer(this.consumer);
                 this.consumer.on('message', (msg) => {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -37,6 +37,7 @@ class RuleExecutor {
                     rule: { name: ruleName, topic },
                     msg: `Listening to ${topicList[0]}`
                 });
+                this._notifySubscribed(topic)
             } else {
                 this.log(`info/subscription/${ruleName}`, {
                     rule: { name: ruleName, topic },
@@ -136,13 +137,14 @@ class RuleExecutor {
      * In production normally one worker will succeed subscribing only to one rule,
      * so this will emit the only rule the worker is processing
      *
-     * @param {string} ruleName the name of the rule this worker is processing.
+     * @param {string} topic topic name this worker subscribed too
      * @private
      */
-    _notifySubscribed(ruleName) {
+    _notifySubscribed(topic) {
         process.emit('service_status', {
             type: 'subscription',
-            rule: ruleName
+            rule: this.rule.name,
+            topic: topic
         });
     }
 
@@ -158,7 +160,6 @@ class RuleExecutor {
             retryTopicName,
             `change-prop-${retryTopicName}-${this.rule.name}`)
         .then((consumer) => {
-            this._notifySubscribed(this.rule.name + '-retry');
             this.retryConsumer = this._setConsumerLoggers(consumer, this.rule.name, retryTopicName);
             this.retryConsumer.on('message', (msg) => {
                 const statName = this.hyper.metrics.normalizeName(this.rule.name + '_retry');
@@ -284,7 +285,6 @@ class RuleExecutor {
         .then(() => {
             return this.kafkaFactory.newConsumer(client, rule.topic, `change-prop-${rule.name}`)
             .then((consumer) => {
-                this._notifySubscribed(this.rule.name);
                 this.consumer = this._setConsumerLoggers(consumer, rule.name, rule.topic);
                 this.taskQueue.addConsumer(this.consumer);
                 this.consumer.on('message', (msg) => {


### PR DESCRIPTION
Several small improvements:
1. As we do not follow redirects, and must use normalised titles already, receiving a 301 response is a bug and requires looking into - thus log a warning.
2. There was a bug in `hyperswitch` - it stripped out the `followRedirect` property we set. Added a test for this.
3. There's a support in service-runner to log the status message from a worker when it dies - utilise this feature to get more information on debugging.

Depends on https://github.com/wikimedia/hyperswitch/pull/44

cc @wikimedia/services 