### PR TITLE
Added a rule for null_edit processing

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -137,7 +137,7 @@ services:
                         query:
                           redirect: false
 
-                    mw_purge:
+                    null_edit:
                       topic: resource_change
                       match:
                         meta:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -137,6 +137,22 @@ services:
                         query:
                           redirect: false
 
+                    mw_purge:
+                      topic: resource_change
+                      match:
+                        meta:
+                          uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
+                        tags:
+                          - null_edit
+                      exec:
+                        method: get
+                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                        headers:
+                          cache-control: no-cache
+                          if-unmodified-since: '{{date(message.meta.dt)}}'
+                        query:
+                          redirect: false
+
                     page_edit:
                       topic: mediawiki.revision_create
                       exec:


### PR DESCRIPTION
In the previous PR `null_edit` events were forgotten. Add a separate rule to process them

cc @wikimedia/services 