### PR TITLE
Small improvements in logging and proper support for 0 retry_limit

### DIFF
--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -45,10 +45,9 @@ class RuleExecutor {
                 });
             }
         });
-        consumer.on('error', (err) => this.log(`warn/error/${ruleName}`, {
-            err,
+        consumer.on('error', (err) => this.log(`warn/${ruleName}`, Object.assign({}, err, {
             rule: { name: ruleName, topic }
-        }));
+        })));
         return consumer;
     }
 
@@ -121,11 +120,20 @@ class RuleExecutor {
         return 'change-prop.retry.' + this.rule.topic;
     }
 
-    _isLimitExceeded(message) {
+    /**
+     * Checks whether retry limit for this rule is exceeded.
+     *
+     * @param {Object} message a retry message to check
+     * @param {Error} [e] optional Error that caused a retry
+     * @returns {boolean}
+     * @private
+     */
+    _isLimitExceeded(message, e) {
         if (message.retries_left <= 0) {
             this.log(`error/${this.rule.name}`, {
                 message: 'Retry count exceeded',
-                event: message
+                event: message,
+                error: e
             });
             return true;
         }
@@ -194,7 +202,7 @@ class RuleExecutor {
                             const retryMessage = this._constructRetryMessage(message.original_event,
                                 e, message.retries_left - 1, message);
                             if (this.rule.shouldRetry(e)) {
-                                if (this._isLimitExceeded(retryMessage)) {
+                                if (this._isLimitExceeded(retryMessage, e)) {
                                     return this.hyper.post({
                                         uri: '/sys/queue/events',
                                         body: [this._constructErrorMessage(e, message)]
@@ -302,7 +310,16 @@ class RuleExecutor {
                             this._exec.bind(this, message, statName),
                             (e) => {
                                 if (this.rule.shouldRetry(e)) {
-                                    return this._retry(this._constructRetryMessage(message, e));
+                                    const retryMessage = this._constructRetryMessage(message, e);
+                                    // Retry limit might be 0,
+                                    // so check if we need to post a retry message at all.
+                                    if (this._isLimitExceeded(retryMessage, e)) {
+                                        return this.hyper.post({
+                                            uri: '/sys/queue/events',
+                                            body: [this._constructErrorMessage(e, message)]
+                                        });
+                                    }
+                                    return this._retry(retryMessage);
                                 }
                             }
                         ));


### PR DESCRIPTION
Various small improvements:
1. Include the error in the retry limit exceeded logs.
2. Log the error directly for driver issues, this will properly fill in the log message
3. retry_limit might be 0, in this case we don't need to post the retry message at all.

cc @wikimedia/services 