### PR TITLE
User-Agent is not propagated by change-prop

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -7,6 +7,7 @@ services:
     module: hyperswitch
     conf:
       port: 7272
+      user_agent: SampleChangePropInstance
       spec:
         x-sub-request-filters:
           - type: default
@@ -14,6 +15,8 @@ services:
             options:
               allow:
                 - pattern: /^https?:\/\//
+                  forward_headers:
+                    user-agent: true
         title: The Change Propagation root
         paths:
           /sys/purge:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -6,6 +6,7 @@ services:
   - name: changeprop
     module: hyperswitch
     conf:
+      user_agent: ChangePropTestSuite
       port: 7272
       spec:
         x-sub-request-filters:
@@ -14,6 +15,8 @@ services:
             options:
               allow:
                 - pattern: /^https?:\/\//
+                  forward_headers:
+                    user-agent: true
         title: The Change Propagation root
         paths:
           /sys/links:
@@ -32,7 +35,7 @@ services:
                   uri: 127.0.0.1:2181
                   consume_dc: test_dc
                   produce_dc: test_dc
-                  concurrency: 2
+                  concurrency: 1
                   templates:
                     simple_test_rule:
                       topic: simple_test_rule

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -67,7 +67,8 @@ describe('Basic rule management', function() {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
-                'x-triggered-by': 'simple_test_rule:/sample/uri'
+                'x-triggered-by': 'simple_test_rule:/sample/uri',
+                'user-agent': 'ChangePropTestSuite'
             }
         })
         .post('/', {
@@ -121,7 +122,8 @@ describe('Basic rule management', function() {
             reqheaders: {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'ChangePropTestSuite'
             }
         })
         .post('/', {
@@ -151,7 +153,8 @@ describe('Basic rule management', function() {
             reqheaders: {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'ChangePropTestSuite'
             }
         })
         .post('/', {
@@ -201,6 +204,7 @@ describe('Basic rule management', function() {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'ChangePropTestSuite'
             }
         })
         .post('/', {
@@ -237,14 +241,14 @@ describe('Basic rule management', function() {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
-                'x-triggered-by': 'simple_test_rule:/sample/uri'
+                'x-triggered-by': 'simple_test_rule:/sample/uri',
+                'user-agent': 'ChangePropTestSuite'
             }
         })
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
         })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
         .reply(404, {});
 
         return producer.sendAsync([{
@@ -262,14 +266,14 @@ describe('Basic rule management', function() {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
-                'x-triggered-by': 'simple_test_rule:/sample/uri'
+                'x-triggered-by': 'simple_test_rule:/sample/uri',
+                'user-agent': 'ChangePropTestSuite'
             }
         })
         .post('/', {
             'test_field_name': 'test_field_value',
             'derived_field': 'test'
         })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
         .reply(200, {});
 
         return producer.sendAsync([{
@@ -286,7 +290,8 @@ describe('Basic rule management', function() {
             reqheaders: {
                 test_header_name: 'test_header_value',
                 'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'ChangePropTestSuite'
             }
         })
         .post('/', {

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -44,6 +44,7 @@ describe('RESTBase update rules', function() {
                 'cache-control': 'no-cache',
                 'x-triggered-by': 'resource_change:https://en.wikipedia.org/api/rest_v1/page/html/Main%20Page',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/summary/Main%20Page')
@@ -78,6 +79,7 @@ describe('RESTBase update rules', function() {
                 'cache-control': 'no-cache',
                 'x-triggered-by': 'resource_change:https://en.wiktionary.org/api/rest_v1/page/html/Main%20Page',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/definition/Main%20Page')
@@ -112,6 +114,7 @@ describe('RESTBase update rules', function() {
                 'cache-control': 'no-cache',
                 'x-triggered-by': 'resource_change:https://en.wikipedia.org/api/rest_v1/page/html/Main%20Page',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/mobile-sections/Main%20Page')
@@ -145,6 +148,7 @@ describe('RESTBase update rules', function() {
             reqheaders: {
                 'cache-control': 'no-cache',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/definition/User%3APchelolo')
@@ -184,7 +188,8 @@ describe('RESTBase update rules', function() {
                 'cache-control': 'no-cache',
                 'x-triggered-by': 'resource_change:https://en.wikipedia.org/wiki/Main_Page',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
-                'if-unmodified-since': 'Thu, 01 Jan 1970 00:00:01 +0000'
+                'if-unmodified-since': 'Thu, 01 Jan 1970 00:00:01 +0000',
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/html/Main_Page')
@@ -220,7 +225,8 @@ describe('RESTBase update rules', function() {
                 'x-triggered-by': 'mediawiki.revision_create:/edit/uri',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
                 'x-restbase-parentrevision': '1233',
-                'if-unmodified-since': 'Thu, 01 Jan 1970 00:00:01 +0000'
+                'if-unmodified-since': 'Thu, 01 Jan 1970 00:00:01 +0000',
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/html/User%3APchelolo%2FTest/1234')
@@ -257,7 +263,8 @@ describe('RESTBase update rules', function() {
             reqheaders: {
                 'cache-control': 'no-cache',
                 'x-triggered-by': 'mediawiki.page_delete:/delete/uri',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/title/User%3APchelolo%2FTest')
@@ -291,7 +298,8 @@ describe('RESTBase update rules', function() {
             reqheaders: {
                 'cache-control': 'no-cache',
                 'x-triggered-by': 'mediawiki.page_restore:/restore/uri',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/html/User%3APchelolo%2FTest')
@@ -325,7 +333,8 @@ describe('RESTBase update rules', function() {
             reqheaders: {
                 'cache-control': 'no-cache',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
-                'x-triggered-by': 'mediawiki.page_move:/move/uri'
+                'x-triggered-by': 'mediawiki.page_move:/move/uri',
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/title/User%3APchelolo%2FTest')
@@ -366,7 +375,8 @@ describe('RESTBase update rules', function() {
             reqheaders: {
                 'cache-control': 'no-cache',
                 'x-triggered-by': 'mediawiki.revision_visibility_set:/rev/uri',
-                'x-request-id': common.SAMPLE_REQUEST_ID
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
             }
         })
         .get('/api/rest_v1/page/revision/1234')


### PR DESCRIPTION
After https://github.com/wikimedia/hyperswitch/pull/41 change-prop doesn't forward a `User-Agent` header to services. Fix it. 

PS: this will require a corresponding change in puppet, this PR is effectively a no-op in prod.

cc @wikimedia/services 