### PR TITLE
Trace log the complete result of the event processing for sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 Dockerfile
 coverage
 node_modules
-npm-debug.log
+npm-debug.log*
 *~
 
 .idea/*

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -122,7 +122,7 @@ class RuleExecutor {
                     });
                 }
             })
-            .tap(this._sampleLog.bind(retryEvent || origEvent, request))
+            .tap(this._sampleLog.bind(this, retryEvent || origEvent, request))
             .catch((e) => {
                 this._sampleLog(retryEvent || origEvent, request, e);
                 throw e;
@@ -186,6 +186,25 @@ class RuleExecutor {
         });
     }
 
+    _catch(message, retryMessage, e) {
+        if (e.constructor.name !== 'HTTPError') {
+            // We've got an error, but it's not from the update request, it's
+            // some bug in change-prop. Log and send a fatal error message.
+            this.hyper.log(`error/${this.rule.name}`, {
+                message: 'Internal error in change-prop',
+                error: e,
+                event: message
+            });
+        } else if (this.rule.shouldRetry(e)
+            && !this._isLimitExceeded(retryMessage, e)) {
+            return this._retry(retryMessage);
+        }
+        return this.hyper.post({
+            uri: '/sys/queue/events',
+            body: [this._constructErrorMessage(e, message)]
+        });
+    }
+
     /**
      * Set's up a consumer a retry queue
      *
@@ -232,15 +251,7 @@ class RuleExecutor {
                             e = decodeError(e);
                             const retryMessage = this._constructRetryMessage(message.original_event,
                                 e, message.retries_left - 1, message);
-                            if (this.rule.shouldRetry(e)) {
-                                if (this._isLimitExceeded(retryMessage, e)) {
-                                    return this.hyper.post({
-                                        uri: '/sys/queue/events',
-                                        body: [this._constructErrorMessage(e, message)]
-                                    });
-                                }
-                                return this._retry(retryMessage);
-                            }
+                            return this._catch(message, retryMessage, e);
                         }
                     ));
                 });
@@ -340,19 +351,9 @@ class RuleExecutor {
                             msg,
                             this._exec.bind(this, message, statName),
                             (e) => {
+                                const retryMessage = this._constructRetryMessage(message, e);
                                 e = decodeError(e);
-                                if (this.rule.shouldRetry(e)) {
-                                    const retryMessage = this._constructRetryMessage(message, e);
-                                    // Retry limit might be 0,
-                                    // so check if we need to post a retry message at all.
-                                    if (this._isLimitExceeded(retryMessage, e)) {
-                                        return this.hyper.post({
-                                            uri: '/sys/queue/events',
-                                            body: [this._constructErrorMessage(e, message)]
-                                        });
-                                    }
-                                    return this._retry(retryMessage);
-                                }
+                                return this._catch(message, retryMessage, e);
                             }
                         ));
                     });

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -113,7 +113,7 @@ class RuleExecutor {
                     message: 'Processed event sample',
                     event: retryEvent || origEvent,
                     request: request,
-                    response: Object.assign(res)
+                    response: Object.assign({}, res)
                 };
                 // Don't include the full body in the log
                 if (res.status === 200 || res.status === 201) {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -76,6 +76,20 @@ class RuleExecutor {
         }
     }
 
+    _sampleLog(event, request, res) {
+        const sampleLog = {
+            message: 'Processed event sample',
+            event: event,
+            request: request,
+            response: Object.assign({}, res)
+        };
+        // Don't include the full body in the log
+        if (res.status === 200 || res.status === 201) {
+            delete sampleLog.response.body;
+        }
+        this.hyper.log('trace/sample', sampleLog);
+    }
+
     _exec(origEvent, statName, statDelayStartTime, retryEvent) {
         const rule = this.rule;
 
@@ -108,18 +122,10 @@ class RuleExecutor {
                     });
                 }
             })
-            .tap((res) => {
-                const sampleLog = {
-                    message: 'Processed event sample',
-                    event: retryEvent || origEvent,
-                    request: request,
-                    response: Object.assign({}, res)
-                };
-                // Don't include the full body in the log
-                if (res.status === 200 || res.status === 201) {
-                    delete sampleLog.response.body;
-                }
-                this.hyper.log('trace/sample', sampleLog);
+            .tap(this._sampleLog.bind(retryEvent || origEvent, request))
+            .catch((e) => {
+                this._sampleLog(retryEvent || origEvent, request, e);
+                throw e;
             });
         })
         .finally(() => {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -107,6 +107,19 @@ class RuleExecutor {
                         event: origEvent
                     });
                 }
+            })
+            .tap((res) => {
+                const sampleLog = {
+                    message: 'Processed event sample',
+                    event: retryEvent || origEvent,
+                    request: request,
+                    response: Object.assign(res)
+                };
+                // Don't include the full body in the log
+                if (res.status === 200 || res.status === 201) {
+                    delete sampleLog.response.body;
+                }
+                this.hyper.log('trace/sample', sampleLog);
             });
         })
         .finally(() => {

--- a/sys/purge.js
+++ b/sys/purge.js
@@ -37,7 +37,13 @@ class PurgeService {
                 return 'http:' + event.meta.uri;
             }
         }).filter((event) => !!event))
-        .thenReturn({ status: 201 });
+        .thenReturn({ status: 201 })
+        .catch((e) => {
+            throw new HTTPError({
+                status: 500,
+                details: e.message
+            });
+        });
     }
 }
 

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -15,7 +15,7 @@ var ChangeProp = function(configPath) {
     this._config.num_workers = 0;
     this._config.logging = {
         name: 'change-prop',
-        level: 'error',
+        level: 'fatal',
         streams: [{ type: 'stdout'}]
     };
     this._runner = new ServiceRunner();


### PR DESCRIPTION
Sampled logging proved to be extremely useful in debugging and identifying issues in RESTBase. It's a good idea to add the same thing to change-prop.

In order to work we need to set up sample_logging config in puppet with some probability for this to be logged.

Other enhancement is that when the error is not an HTTPError, but some kind of internal change-prop error - log it and don't even try to retry.

cc @wikimedia/services 