### PR TITLE
Updated tests to use service-runner v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cassandra-uuid": "^0.0.2",
     "extend": "^3.0.0",
     "hyperswitch": "^0.5.2",
-    "service-runner": "^1.3.1",
+    "service-runner": "^2.0.1",
     "wmf-kafka-node": "^0.1.3",
     "json-stable-stringify": "^1.0.1",
     "htcp-purge": "^0.1.2"

--- a/test/feature/startup.js
+++ b/test/feature/startup.js
@@ -55,7 +55,7 @@ describe('Startup', function () {
         .delay(1000)
         .finally(() => {
             if (!finished) {
-                changeProp.stop().then(done);
+                changeProp.stop().then(() => done());
             }
             nock.cleanAll()
         });

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -26,14 +26,7 @@ ChangeProp.prototype._loadConfig = function() {
 };
 
 ChangeProp.prototype.start = function() {
-    var self = this;
-    self.port = self._config.services[0].conf.port;
-    self.hostPort = 'http://localhost:' + self.port;
-    return self._runner.run(self._config)
-    .then(function(servers) {
-        self._servers = servers;
-        return true;
-    })
+    return this._runner.start(this._config)
     .delay(200)
     .catch((e) => {
         if (startupRetryLimit > 0 && /EADDRINUSE/.test(e.message)) {
@@ -46,18 +39,7 @@ ChangeProp.prototype.start = function() {
 };
 
 ChangeProp.prototype.stop = function() {
-    var self = this;
-    if (self._servers) {
-        return P.each(self._servers, function(server) {
-            return server.close();
-        })
-        .then(function() {
-            self._servers = undefined;
-        })
-        .delay(CHANGE_PROP_STOP_DELAY);
-    } else {
-        return P.delay(CHANGE_PROP_STOP_DELAY);
-    }
+    return this._runner.stop().delay(CHANGE_PROP_STOP_DELAY);
 };
 
 module.exports = ChangeProp;


### PR DESCRIPTION
The second version of `service-runner` has a different interface for starting and stopping the services.
We use that in tests to start/stop change-prop with various configs, so tests should be updated to match the new service-runner interface. Test-only fix since the other major change in `service-runner` interface, removal of the `core-js` is a no-op, hyperswitch exports `core-js` instead of the `service-runner`.

cc @wikimedia/services 