### PR TITLE
Rerender summary when wikidata item is updated

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -482,6 +482,30 @@ spec: &spec
                   headers:
                     cache-control: no-cache
 
+              wikidata_description:
+                topic: mediawiki.revision_create
+                match:
+                  meta:
+                    domain: www.wikidata.org
+                exec:
+                  method: 'post'
+                  uri: '/sys/links/wikidata_descriptions'
+                  body: '{{globals.message}}'
+
+              on_wikidata_description_change:
+                topic: resource_change
+                match:
+                  meta:
+                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+                  tags: [ 'change-prop', 'wikidata' ]
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
+                  query:
+                    redirect: false
+
 num_workers: 0
 logging:
   name: changeprop

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -246,7 +246,7 @@ class DependencyProcessor {
             body: items.map((item) => {
                 // TODO: need to check whether a wiki is http or https!
                 const resourceURI =
-                    `https://${originalEvent.meta.domain}/wiki/${encodeURIComponent(item.title)}`;
+                    `https://${item.domain}/wiki/${encodeURIComponent(item.title)}`;
                 return {
                     meta: {
                         topic: 'resource_change',

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -439,7 +439,7 @@ describe('RESTBase update rules', function() {
             }
         });
 
-        const mwAPI = nock('https://en.wikipedia.org', {
+        const restbase = nock('https://en.wikipedia.org', {
             reqheaders: {
                 'cache-control': 'no-cache',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
@@ -451,28 +451,24 @@ describe('RESTBase update rules', function() {
         .query({ redirect: false })
         .reply(200, { });
 
-        return producer.sendAsync([{
+        return producer.produceAsync({
             topic: 'test_dc.mediawiki.revision_create',
-            messages: [
-                JSON.stringify({
-                    meta: {
-                        topic: 'mediawiki.revision_create',
-                        schema_uri: 'revision_create/1',
-                        uri: '/rev/uri',
-                        request_id: common.SAMPLE_REQUEST_ID,
-                        id: uuid.now(),
-                        dt: new Date().toISOString(),
-                        domain: 'www.wikidata.org'
-                    },
-                    page_title: 'Q1'
-                })
-            ]
-        }])
-        .delay(common.REQUEST_CHECK_DELAY)
-        .then(() => {
-            wikidataAPI.done();
-            mwAPI.done();
+            message: JSON.stringify({
+                meta: {
+                    topic: 'mediawiki.revision_create',
+                    schema_uri: 'revision_create/1',
+                    uri: '/rev/uri',
+                    request_id: common.SAMPLE_REQUEST_ID,
+                    id: uuid.now(),
+                    dt: new Date().toISOString(),
+                    domain: 'www.wikidata.org'
+                },
+                page_title: 'Q1'
+            })
         })
+        .delay(common.REQUEST_CHECK_DELAY)
+        .then(() => common.checkAPIDone(wikidataAPI))
+        .then(() => common.checkAPIDone(restbase))
         .finally(() => nock.cleanAll());
     });
 


### PR DESCRIPTION
When a wikidata page is changed, the item description might have been changed too - thus rerender summary as we wanna be able to include the description into the summary and purge it.

Related PR: https://github.com/wikimedia/restbase/pull/625
Bug: https://phabricator.wikimedia.org/T128894

cc @wikimedia/services 