### PR TITLE
Enable all transclusions updates in CP

### DIFF
--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -187,12 +187,12 @@ class DependencyProcessor {
         return this._getSiteInfo(hyper, message)
         .then((siteInfo) => {
             const title = Title.newFromText(req.params.title, siteInfo);
-            // First step - process only file uploads
             if (title.getNamespace().isFile()) {
                 return this._fetchAndProcessBatch(hyper, this.imageLinksRequest,
                     context, siteInfo, originalEvent);
             }
-            return { status: 200 };
+            return this._fetchAndProcessBatch(hyper, this.transcludeInRequest,
+                context, siteInfo, originalEvent);
         });
     }
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -671,14 +671,11 @@ describe('RESTBase update rules', function() {
         .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Transcluded_Here')
         .reply(200);
 
-        return producer.sendAsync([{
+        return producer.produceAsync({
             topic: 'test_dc.mediawiki.revision_create',
-            messages: [
-                JSON.stringify(common.eventWithProperties('mediawiki.revision_create', { page_title: 'Test_Page' }))
-            ]
-        }])
-        .delay(common.REQUEST_CHECK_DELAY)
-        .then(() => mwAPI.done())
+            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', { page_title: 'Test_Page' }))
+        })
+        .then(() => common.checkAPIDone(mwAPI, 50))
         .finally(() => nock.cleanAll());
     });
 


### PR DESCRIPTION
After https://github.com/wikimedia/change-propagation/pull/38 will be deployed, tested and verified it's working, we'd need to enable all the rest of the transclusion processing in Change-Prop. This PR contains code changes required for that, and a test. 

It's a bit premature to review/merge/deploy, but I'll just leave it here until we're ready for it.

cc @wikimedia/services 