### PR TITLE
Test stability improvements

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -19,6 +19,16 @@ services:
                     user-agent: true
         title: The Change Propagation root
         paths:
+          # Test-only endpoint for a graceful service shutdown
+          # It's needed in the
+          /v1/close:
+            post:
+              x-request-handler:
+                - do_close:
+                    request:
+                      method: post
+                      uri: /sys/queue/close
+
           /sys/purge:
             x-modules:
               - path: sys/purge.js

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -19,16 +19,6 @@ services:
                     user-agent: true
         title: The Change Propagation root
         paths:
-          # Test-only endpoint for a graceful service shutdown
-          # It's needed in the
-          /v1/close:
-            post:
-              x-request-handler:
-                - do_close:
-                    request:
-                      method: post
-                      uri: /sys/queue/close
-
           /sys/purge:
             x-modules:
               - path: sys/purge.js

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -19,6 +19,14 @@ services:
                     user-agent: true
         title: The Change Propagation root
         paths:
+          # Test-only endpoint for a graceful service shutdown
+          /v1/close:
+            post:
+              x-request-handler:
+                - do_close:
+                    request:
+                      method: post
+                      uri: /sys/queue/close
           /sys/links:
             x-modules:
               - path: sys/dep_updates.js
@@ -38,6 +46,7 @@ services:
                   consume_dc: test_dc
                   produce_dc: test_dc
                   concurrency: 1
+                  commit_interval: 0
                   templates:
                     simple_test_rule:
                       topic: simple_test_rule
@@ -60,6 +69,7 @@ services:
                         body:
                           test_field_name: test_field_value
                           derived_field: '{{message.message}}'
+                          random_field: '{{message.random}}'
 
                     redirect_testing_rule:
                       topic: simple_test_rule

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -46,7 +46,6 @@ services:
                   consume_dc: test_dc
                   produce_dc: test_dc
                   concurrency: 1
-                  commit_interval: 0
                   templates:
                     simple_test_rule:
                       topic: simple_test_rule

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -19,14 +19,6 @@ services:
                     user-agent: true
         title: The Change Propagation root
         paths:
-          # Test-only endpoint for a graceful service shutdown
-          /v1/close:
-            post:
-              x-request-handler:
-                - do_close:
-                    request:
-                      method: post
-                      uri: /sys/queue/close
           /sys/links:
             x-modules:
               - path: sys/dep_updates.js

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -379,6 +379,12 @@ class RuleExecutor {
             });
         });
     }
+
+    close() {
+        return this.taskQueue.close()
+        .then(this.retryConsumer.closeAsync.bind(this.retryConsumer))
+        .then(this.consumer.closeAsync.bind(this.consumer));
+    }
 }
 
 module.exports = RuleExecutor;

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -185,6 +185,29 @@ class TaskQueue extends EventEmitter {
         }
     }
 
+    _doCommit() {
+        return P.each(this._pendingCommits.keys(), (consumer) => {
+            if (!consumer.rebalancing) {
+                const topicsOffsets = this._pendingCommits.get(consumer);
+                return P.each(Object.keys(topicsOffsets), (topic) => {
+                    consumer.isCommitting = true;
+                    return KafkaFactory.commit(consumer, topic, topicsOffsets[topic])
+                    .then(() => {
+                        consumer.isCommitting = false;
+                        if (!this._isPaused) {
+                            consumer.resume();
+                        }
+                    });
+                })
+                .then(() => {
+                    this._pendingCommits.delete(consumer);
+                });
+            }
+        })
+        .then(() => {
+            this._commitScheduled = false;
+        });
+    }
     /**
      * Schedules a commit for pending commit requests
      *
@@ -195,25 +218,17 @@ class TaskQueue extends EventEmitter {
             return;
         }
 
-        setTimeout(() => {
-            this._pendingCommits.forEach((topicsOffsets, consumer) => {
-                if (!consumer.rebalancing) {
-                    Object.keys(topicsOffsets).forEach((topic) => {
-                        consumer.isCommitting = true;
-                        KafkaFactory.commit(consumer, topic, topicsOffsets[topic])
-                        .then(() => {
-                            consumer.isCommitting = false;
-                            if (!this._isPaused) {
-                                consumer.resume();
-                            }
-                        });
-                    });
-                    this._pendingCommits.delete(consumer);
-                }
-            });
-            this._commitScheduled = false;
-        }, this._commitInterval);
+        this._commitTimeout = setTimeout(this._doCommit.bind(this),
+            this._commitInterval);
         this._commitScheduled = true;
+    }
+    
+    close() {
+        if (this._commitTimeout) {
+            clearTimeout(this._commitTimeout);
+            return this._doCommit();
+        }
+        return P.resolve();
     }
 }
 

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -136,8 +136,7 @@ module.exports = (options) => {
         operations: {
             setup_kafka: kafkaMod.setup.bind(kafkaMod),
             produce: kafkaMod.produce.bind(kafkaMod),
-            subscribe: kafkaMod.subscribe.bind(kafkaMod),
-            close: kafkaMod.close.bind(kafkaMod)
+            subscribe: kafkaMod.subscribe.bind(kafkaMod)
         },
         resources: [{
             uri: '/sys/queue/setup'

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -7,7 +7,8 @@
 
 
 const P = require('bluebird');
-const HTTPError = require('hyperswitch').HTTPError;
+const HyperSwitch = require('hyperswitch');
+const HTTPError = HyperSwitch.HTTPError;
 const uuid = require('cassandra-uuid').TimeUuid;
 
 const Rule = require('../lib/rule');
@@ -29,6 +30,10 @@ class Kafka {
         this.staticRules = options.templates || {};
         this.ruleExecutors = {};
         this.taskQueue = new TaskQueue(this.tqOpts);
+
+        HyperSwitch.lifecycle.on('close', () => {
+            this.close();
+        });
     }
 
     setup(hyper) {
@@ -124,12 +129,6 @@ module.exports = (options) => {
                     post: {
                         summary: 'adds a new subscription dynamically',
                         operationId: 'subscribe'
-                    }
-                },
-                '/close': {
-                    post: {
-                        summary: 'Closes all the subscriptions. Used only in the test mode',
-                        operationId: 'close'
                     }
                 }
             }

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -95,6 +95,12 @@ class Kafka {
         }))
         .thenReturn({ status: 201 });
     }
+
+    close() {
+        return P.each(Object.values(this.ruleExecutors),
+            (executor) => executor.close())
+        .thenReturn({ status: 200 });
+    }
 }
 
 module.exports = (options) => {
@@ -119,17 +125,23 @@ module.exports = (options) => {
                         summary: 'adds a new subscription dynamically',
                         operationId: 'subscribe'
                     }
+                },
+                '/close': {
+                    post: {
+                        summary: 'Closes all the subscriptions. Used only in the test mode',
+                        operationId: 'close'
+                    }
                 }
             }
         },
         operations: {
             setup_kafka: kafkaMod.setup.bind(kafkaMod),
             produce: kafkaMod.produce.bind(kafkaMod),
-            subscribe: kafkaMod.subscribe.bind(kafkaMod)
+            subscribe: kafkaMod.subscribe.bind(kafkaMod),
+            close: kafkaMod.close.bind(kafkaMod)
         },
         resources: [{
             uri: '/sys/queue/setup'
         }]
     };
 };
-

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -63,6 +63,7 @@ describe('Basic rule management', function() {
     });
 
     it('Should call simple executor', () => {
+        const random = common.randomString();
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
@@ -74,14 +75,15 @@ describe('Basic rule management', function() {
         })
         .post('/', {
             'test_field_name': 'test_field_value',
-            'derived_field': 'test'
+            'derived_field': 'test',
+            'random_field': random
         }).reply({});
 
         return producer.sendAsync([{
             topic: 'test_dc.simple_test_rule',
             messages: [
-                JSON.stringify(common.eventWithMessage('this_will_not_match')),
-                JSON.stringify(common.eventWithMessage('test')),
+                JSON.stringify(common.eventWithMessageAndRandom('this_will_not_match', random)),
+                JSON.stringify(common.eventWithMessageAndRandom('test', random)),
                 // The empty message should cause a failure in the match test
                 '{}' ]
         }])
@@ -90,35 +92,8 @@ describe('Basic rule management', function() {
         .finally(() => nock.cleanAll());
     });
 
-    it('Should not follow redirects', (done) => {
-        let finished = false;
-        const service = nock('http://mock.com')
-        .get('/will_redirect')
-        .reply(301, '', {
-            'location': 'http://mock.com/redirected_resource'
-        })
-        .get('/redirected_resource')
-        .reply(() => {
-            finished = true;
-            done(new Error('Must not have followed the redirect'))
-        });
-
-        return producer.sendAsync([{
-            topic: 'test_dc.simple_test_rule',
-            messages: [
-                JSON.stringify(common.eventWithMessage('redirect'))
-            ]
-        }])
-        .delay(common.REQUEST_CHECK_DELAY)
-        .finally(() => {
-            nock.cleanAll();
-            if (!finished) {
-                done();
-            }
-        });
-    });
-
     it('Should retry simple executor', () => {
+        const random = common.randomString();
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
@@ -129,27 +104,30 @@ describe('Basic rule management', function() {
         })
         .post('/', {
             'test_field_name': 'test_field_value',
-            'derived_field': 'test'
+            'derived_field': 'test',
+            'random_field': random
         })
         .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
         .reply(500, {})
         .post('/', {
             'test_field_name': 'test_field_value',
-            'derived_field': 'test'
+            'derived_field': 'test',
+            'random_field': random
         })
         .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
         .reply(200, {});
 
         return producer.sendAsync([{
             topic: 'test_dc.simple_test_rule',
-            messages: [ JSON.stringify(common.eventWithMessage('test')) ]
+            messages: [ JSON.stringify(common.eventWithMessageAndRandom('test', random)) ]
         }])
         .delay(common.REQUEST_CHECK_DELAY)
         .then(() => service.done())
         .finally(() => nock.cleanAll());
     });
 
-    it('Should emit valid retry message', (done) => {
+    it('Should retry simple executor no more than limit', () => {
+        const random = common.randomString();
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
@@ -160,12 +138,64 @@ describe('Basic rule management', function() {
         })
         .post('/', {
             'test_field_name': 'test_field_value',
-            'derived_field': 'test'
+            'derived_field': 'test',
+            'random_field': random
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
+        .reply(500, {})
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test',
+            'random_field': random
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
+        .reply(500, {})
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test',
+            'random_field': random
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
+        .reply(500, {})
+        // Next one must never get called, we verify that by checking pending mocks
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test',
+            'random_field': random
+        })
+        .reply(500, {});
+
+        return producer.sendAsync([{
+            topic: 'test_dc.simple_test_rule',
+            messages: [ JSON.stringify(common.eventWithMessageAndRandom('test', random)) ]
+        }])
+        .delay(common.REQUEST_CHECK_DELAY)
+        .then(() => {
+            assert.equal(service.pendingMocks().length, 1);
+        })
+        .finally(() => nock.cleanAll());
+    });
+
+    it('Should emit valid retry message', (done) => {
+        const random = common.randomString();
+        nock('http://mock.com', {
+            reqheaders: {
+                test_header_name: 'test_header_value',
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'ChangePropTestSuite'
+            }
+        })
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test',
+            'random_field': random
         })
         .reply(500, {})
         .post('/', {
             'test_field_name': 'test_field_value',
-            'derived_field': 'test'
+            'derived_field': 'test',
+            'random_field': random
         })
         .reply(200, {});
         
@@ -194,62 +224,13 @@ describe('Basic rule management', function() {
             });
             return producer.sendAsync([{
                 topic: 'test_dc.simple_test_rule',
-                messages: [ JSON.stringify(common.eventWithMessage('test')) ]
+                messages: [ JSON.stringify(common.eventWithMessageAndRandom('test', random)) ]
             }]);
         });
     });
 
-    it('Should retry simple executor no more than limit', (done) => {
-        let finished = false;
-        nock('http://mock.com', {
-            reqheaders: {
-                test_header_name: 'test_header_value',
-                'content-type': 'application/json',
-                'x-request-id': common.SAMPLE_REQUEST_ID,
-                'user-agent': 'ChangePropTestSuite'
-            }
-        })
-        .post('/', {
-            'test_field_name': 'test_field_value',
-            'derived_field': 'test'
-        })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
-        .reply(500, {})
-        .post('/', {
-            'test_field_name': 'test_field_value',
-            'derived_field': 'test'
-        })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
-        .reply(500, {})
-        .post('/', {
-            'test_field_name': 'test_field_value',
-            'derived_field': 'test'
-        })
-        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri,change-prop.retry.simple_test_rule:/sample/uri')
-        .reply(500, {})
-        .post('/', {
-            'test_field_name': 'test_field_value',
-            'derived_field': 'test'
-        })
-        .reply(() => {
-            finished = true;
-            done(new Error('Must not have retried this time'))
-        });
-
-        return producer.sendAsync([{
-            topic: 'test_dc.simple_test_rule',
-            messages: [ JSON.stringify(common.eventWithMessage('test')) ]
-        }])
-        .delay(common.REQUEST_CHECK_DELAY)
-        .finally(() => {
-            if (!finished) {
-                done();
-            }
-            nock.cleanAll()
-        });
-    });
-
     it('Should not retry if retry_on not matched', () => {
+        const random = common.randomString();
         const service = nock('http://mock.com', {
             reqheaders: {
                 test_header_name: 'test_header_value',
@@ -261,16 +242,45 @@ describe('Basic rule management', function() {
         })
         .post('/', {
             'test_field_name': 'test_field_value',
-            'derived_field': 'test'
+            'derived_field': 'test',
+            'random_field': random
+        })
+        .reply(404, {})
+        // Next one must never get called, we verify that by checking pending mocks
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test',
+            'random_field': random
         })
         .reply(404, {});
 
         return producer.sendAsync([{
             topic: 'test_dc.simple_test_rule',
-            messages: [ JSON.stringify(common.eventWithMessage('test')) ]
+            messages: [ JSON.stringify(common.eventWithMessageAndRandom('test', random)) ]
         }])
         .delay(common.REQUEST_CHECK_DELAY)
-        .then(() => service.done())
+        .then(() => assert.equal(service.pendingMocks().length, 1))
+        .finally(() => nock.cleanAll());
+    });
+
+    it('Should not follow redirects', () => {
+        const service = nock('http://mock.com/')
+        .get('/will_redirect')
+        .reply(301, '', {
+            'location': 'http://mock.com/redirected_resource'
+        })
+        // Next one must never get called, we verify that by checking pending mocks
+        .get('/redirected_resource')
+        .reply(200, {});
+
+        return producer.sendAsync([{
+            topic: 'test_dc.simple_test_rule',
+            messages: [
+                JSON.stringify(common.eventWithMessage('redirect'))
+            ]
+        }])
+        .delay(common.REQUEST_CHECK_DELAY)
+        .then(() => assert.equal(service.pendingMocks().length, 1))
         .finally(() => nock.cleanAll());
     });
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -494,7 +494,8 @@ describe('RESTBase update rules', function() {
                 JSON.stringify(common.eventWithProperties('mediawiki.revision_create', { page_title: 'File:Test.jpg' }))
             ]
         }])
-        .delay(common.REQUEST_CHECK_DELAY)
+        // Larger delay since it's a long list of events
+        .delay(common.REQUEST_CHECK_DELAY * 2)
         .then(() => mwAPI.done())
         .finally(() => nock.cleanAll());
     });

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -51,10 +51,7 @@ ChangeProp.prototype.start = function() {
 
 ChangeProp.prototype.stop = function() {
     if (this._running) {
-        return preq.post({
-            uri: this.hostPort + '/v1/close'
-        })
-        .then(() => this._runner.stop())
+        this._runner.stop()
         .tap(() => this._running = false)
         .delay(CHANGE_PROP_STOP_DELAY);
     }

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -55,6 +55,22 @@ common.eventWithMessage = (message) => {
     return common.eventWithProperties('simple_test_rule', { message: message });
 };
 
+common.eventWithMessageAndRandom = (message, random) => {
+    return common.eventWithProperties('simple_test_rule', {
+        message: message,
+        random: random
+    });
+};
+
+common.randomString = () => {
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let text = '';
+    while (text.length < 5) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+};
+
 common.arrayWithLinks = function(link, num) {
     const result = [];
     for(let idx = 0; idx < num; idx++) {


### PR DESCRIPTION
There was several issues with test stability:
 -  If one test failed for some reason, it could post an unexpected retry message that's processed by another test and fail it too. Separated the tests better by introducing a randomised field to the test events so that events from different tests don't mix up.
 -  When we call `service-runner.stop()` we only close the HTTP server created by `huperswitch`. But for change-propagation that's not enough - we also need to close kafka consumers, or some events might be processed twice, thus the tests were failing. 
I can't say I like the solution with an artificial `close` endpoint, but that's the simplest one. Alternative options: either make a module emit `server_close` event when the server is closed or introduce a concept of a module 'destructor'. This is not really important in production since we're not using `service-runner.close` there.
 -  Some of the tests were verifying that something is NOT done, and a nock endpoint is not called. Implementing a better way to verify that by comparing the `pendingMocks` with an expected number of pending mocks and used it in tests

cc @wikimedia/services 