### PR TITLE
Do not decrement the offset to commit

### DIFF
--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -105,13 +105,6 @@ class TaskQueue extends EventEmitter {
         .filter(task.isTaskForSamePartition.bind(task))
         .map((item) => item.offset);
         let newOffset = Math.min.apply(null, pendingPartitionTasks);
-        if (newOffset !== task.offset) {
-            // In case we have unfinished tasks with offsets lower then
-            // the current finished task offset, decrement it since this
-            // means the task with newOffset is still panding, but the one with
-            // a lower offset is already finished.
-            newOffset--;
-        }
         if (current && current >= newOffset) {
             // A higher offset is already scheduled for commit
             return;


### PR DESCRIPTION
According to the Kafka docs:

> Note: The committed offset should always be the offset of the next
> message that your application will read.

Hence, decrementing the offset actually means that the message being
currently worked on will be processed twice in case another Change Prop
worker obtains ownership of the partition.