### PR TITLE
Register rules sequantially

### DIFF
--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -41,14 +41,14 @@ class Kafka {
     }
 
     _subscribeRules(hyper, rules) {
-        return P.all(Object.keys(rules)
-        .map((ruleName) => new Rule(ruleName, rules[ruleName]))
-        .filter((rule) => !rule.noop)
-        .map((rule) => {
+        const activeRules = Object.keys(rules)
+            .map((ruleName) => new Rule(ruleName, rules[ruleName]))
+            .filter((rule) => !rule.noop);
+        return P.each(activeRules, (rule) => {
             this.ruleExecutors[rule.name] = new RuleExecutor(rule,
                 this.kafkaFactory, this.taskQueue, hyper, this.log);
             return this.ruleExecutors[rule.name].subscribe();
-        }))
+        })
         .thenReturn({ status: 201 });
     }
 


### PR DESCRIPTION
On startup change-prop uses A LOT of CPU, affecting other services. To make startup a bit less bursty we need to register the rules sequentially, not in parallel.

Also, there's a report that `kafka-node` might be non-stable under high consumer startup load (https://github.com/SOHU-Co/kafka-node/issues/341) I'm not sure it's true, but better be safe.

cc @wikimedia/services 