### PR TITLE
Don't pause-resume while rebalancing

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -110,11 +110,18 @@ class KafkaFactory {
         }
 
         const oldOffsets = {};
-        consumer.pause();
         consumer.topicPayloads.filter((p) => p.topic === topic)
         .forEach((p) => {
             oldOffsets[p.partition] = p.offset;
         });
+
+        if (!Object.keys(oldOffsets).length) {
+            // By the time we've called a commit, this consumer might not
+            // be subscribed to the topic any more, skip.
+            return P.resolve();
+        }
+
+        consumer.pause();
         setOffsets(offsets);
         return consumer.commitAsync(true)
         .then(() => {

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -64,6 +64,11 @@ class TaskQueue extends EventEmitter {
         if (this._consumers.some((item) => item === consumer)) {
             return false;
         }
+        consumer.on('rebalanced', () => {
+            if (!this._isPaused && consumer.paused) {
+                consumer.resume();
+            }
+        });
         this._consumers.push(consumer);
         return true;
     }

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -164,7 +164,10 @@ class TaskQueue extends EventEmitter {
 
         // enqueue any outstanding tasks
         while (this._queue.length < this._max_size && this._waiting.length > 0) {
-            this._start(this._waiting.shift());
+            const task = this._waiting.shift();
+            if (task.consumer.topicPayloads.some((p) => p.topic === task.topic)) {
+                this._start(task);
+            }
         }
         // resume the consumers if the queue has empty slots
         if (this._queue.length < this._max_size) {

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -144,7 +144,8 @@ class TaskQueue extends EventEmitter {
     _defer(task) {
         // put the task in the waiting queue and pause the consumers
         this._waiting.push(task);
-        this._consumers.forEach((consumer) => consumer.pause());
+        this._consumers.filter((consumer) => !consumer.rebalancing)
+        .forEach((consumer) => consumer.pause());
         this._isPaused = true;
     }
 
@@ -162,7 +163,7 @@ class TaskQueue extends EventEmitter {
         }
         // resume the consumers if the queue has empty slots
         if (this._queue.length < this._max_size) {
-            this._consumers.filter((cons) => cons.paused && !cons.isCommitting)
+            this._consumers.filter((cons) => cons.paused && !cons.isCommitting && !cons.rebalancing)
             .forEach((cons) => cons.resume());
             this._isPaused = false;
         }
@@ -180,18 +181,20 @@ class TaskQueue extends EventEmitter {
 
         setTimeout(() => {
             this._pendingCommits.forEach((topicsOffsets, consumer) => {
-                Object.keys(topicsOffsets).forEach((topic) => {
-                    consumer.isCommitting = true;
-                    KafkaFactory.commit(consumer, topic, topicsOffsets[topic])
-                    .then(() => {
-                        consumer.isCommitting = false;
-                        if (!this._isPaused) {
-                            consumer.resume();
-                        }
+                if (!consumer.rebalancing) {
+                    Object.keys(topicsOffsets).forEach((topic) => {
+                        consumer.isCommitting = true;
+                        KafkaFactory.commit(consumer, topic, topicsOffsets[topic])
+                        .then(() => {
+                            consumer.isCommitting = false;
+                            if (!this._isPaused) {
+                                consumer.resume();
+                            }
+                        });
                     });
-                });
+                    this._pendingCommits.delete(consumer);
+                }
             });
-            this._pendingCommits = new Map();
             this._commitScheduled = false;
         }, this._commitInterval);
         this._commitScheduled = true;

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -15,7 +15,7 @@ var ChangeProp = function(configPath) {
     this._config.num_workers = 0;
     this._config.logging = {
         name: 'change-prop',
-        level: 'fatal',
+        level: 'error',
         streams: [{ type: 'stdout'}]
     };
     this._runner = new ServiceRunner();


### PR DESCRIPTION
It seems like pausing/resuming consumers during a rebalance is not a good idea.

cc @wikimedia/services 