### PR TITLE
Increment committed offset to avoid double-processing

### DIFF
--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -110,6 +110,14 @@ class TaskQueue extends EventEmitter {
         .filter(task.isTaskForSamePartition.bind(task))
         .map((item) => item.offset);
         let newOffset = Math.min.apply(null, pendingPartitionTasks);
+        if (newOffset === task.offset) {
+            // In this case there's no pending tasks with an offset lower then
+            // this finished task offset, so it's safe to move to the next offset.
+            // If there were pending tasks with lower offsets, we couldn't have
+            // incremented the offset since we don't know how if the pending task
+            // fails or not.
+            newOffset++;
+        }
         if (current && current >= newOffset) {
             // A higher offset is already scheduled for commit
             return;


### PR DESCRIPTION
In kafka we need to commit the offset of the next task to be fetched, while we were committing the offset of the currently finished task.

cc @wikimedia/services 