### PR TITLE
Encode URI of the transclusion resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,15 +46,15 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.3",
-    "mocha": "^2.4.5",
-    "mocha-jscs": "^4.2.0",
+    "mocha": "^2.5.3",
+    "mocha-jscs": "^5.0.1",
     "mocha-jshint": "^2.3.1",
     "mocha-lcov-reporter": "^1.2.0",
     "coveralls": "^2.11.9",
-    "js-yaml": "^3.6.0",
+    "js-yaml": "^3.6.1",
     "nock": "^8.0.0",
     "preq": "^0.4.9",
-    "ajv": "^4.0.4"
+    "ajv": "^4.1.3"
   },
   "deploy": {
     "node": "4.3.0",

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -197,12 +197,14 @@ class DependencyProcessor {
         return hyper.post({
             uri: '/sys/queue/events',
             body: items.map((item) => {
+                // TODO: need to check whether a wiki is http or https!
+                const resourceURI =
+                    `https://${originalEvent.meta.domain}/wiki/${encodeURIComponent(item.title)}`;
                 return {
                     meta: {
                         topic: 'resource_change',
                         schema_uri: 'resource_change/1',
-                        // TODO: need to check whether a wiki is http or https!
-                        uri: `https://${originalEvent.meta.domain}/wiki/${item.title}`,
+                        uri: resourceURI,
                         request_id: originalEvent.meta.request_id,
                         domain: originalEvent.meta.domain,
                         dt: originalEvent.meta.dt


### PR DESCRIPTION
We need to encode the title for the `resource_change` events which we produce from the transclusions updates rule.

cc @wikimedia/services 