### PR TITLE
Epic: Bug fix: Do not allow empty messages to be sent to Kafka

### DIFF
--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -161,6 +161,10 @@ class DependencyProcessor {
                     title: Title.newFromText(item.title, siteInfo).getPrefixedDBKey()
                 };
             });
+            if (!titles.length) {
+                // the batch is complete or the list of transcluded titles is empty
+                return { status: 200 };
+            }
             let actions = this._sendResourceChanges(hyper, titles,
                 originalEvent, requestTemplate.resourceChangeTag);
             if (res.body.continue) {

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -58,12 +58,12 @@ class Kafka {
 
     produce(hyper, req) {
         const messages = req.body;
-        if (!Array.isArray(messages)) {
+        if (!Array.isArray(messages) || !messages.length) {
             throw new HTTPError({
                 status: 400,
                 body: {
                     type: 'bad_request',
-                    detail: 'Events should be an array'
+                    detail: 'Events should be a non-empty array'
                 }
             });
         }


### PR DESCRIPTION
For reasons not yet clear at this point, the Promise sending messages to
Kafka never gets fulfilled when an empty array is given to it, which
causes the task queue to accumulate messages and never discard them,
effectively halting the processing for all of the rules that the worker
is managing.

This patch adds a check to the producer end to reject empty arrays (as
it should, regardless of the underlying cause), and intructs the
transclusion updates not to send resource_change events when no titles
are to be re-rendered.