### PR TITLE
Log all errors that go to error topic

### DIFF
--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -187,6 +187,13 @@ class RuleExecutor {
     }
 
     _catch(message, retryMessage, e) {
+        const produceError = () => {
+            return this.hyper.post({
+                uri: '/sys/queue/events',
+                body: [this._constructErrorMessage(e, message)]
+            });
+        };
+
         if (e.constructor.name !== 'HTTPError') {
             // We've got an error, but it's not from the update request, it's
             // some bug in change-prop. Log and send a fatal error message.
@@ -195,14 +202,23 @@ class RuleExecutor {
                 error: e,
                 event: message
             });
-        } else if (this.rule.shouldRetry(e)
-            && !this._isLimitExceeded(retryMessage, e)) {
-            return this._retry(retryMessage);
+            return produceError();
         }
-        return this.hyper.post({
-            uri: '/sys/queue/events',
-            body: [this._constructErrorMessage(e, message)]
-        });
+
+        if (!this.rule.shouldRetry(e)) {
+            this.hyper.log(`error/${this.rule.name}`, {
+                message: 'Non-retriable error',
+                error: e,
+                event: message
+            });
+            return produceError();
+        }
+
+        if (this._isLimitExceeded(retryMessage, e)) {
+            // Logging is done in the limit check
+            return produceError();
+        }
+        return this._retry(retryMessage);
     }
 
     /**


### PR DESCRIPTION
Sometimes we see some elevated rates of errors going to the error topic, but they're not seen in the logs. These are the errors which do no match the retry pattern. While we're stabilising CP it would be useful to see these errors in the logs.

cc @wikimedia/services 