### PR TITLE
Added ability to supply switch statements to the rule

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -132,40 +132,57 @@ class Rule {
         this.spec.retry_on = this.spec.retry_on || {
             status: [ '50x' ]
         };
-        this.shouldRetry = _compileRetryCondition(this.spec.retry_on);
-        this.exec = this._processExec(this.spec.exec);
-        this._match = this._processMatch(this.spec.match);
-        this._match_not = (this._processMatch(this.spec.match_not) || {}).test;
         this.spec.retry_delay = this.spec.retry_delay || DEFAULT_RETRY_DELAY;
         this.spec.retry_limit = this.spec.retry_limit || DEFAULT_RETRY_LIMIT;
         this.spec.retry_factor = this.spec.retry_factor || DEFAULT_RETRY_FACTOR;
+
+        this.shouldRetry = _compileRetryCondition(this.spec.retry_on);
+
+        const switchOptions = this.spec.switch || [ this.spec ];
+        this._options = (this.spec.switch || [ this.spec ]).map((option) => {
+            const matcher = this._processMatch(option.match) || {};
+            return {
+                exec: this._processExec(option.exec),
+                match: matcher.test || (() => true),
+                expand: matcher.expand,
+                match_not: (this._processMatch(option.match_not) || {}).test || (() => false)
+            };
+        });
     }
 
     /**
-     * Tests the message against the compiled evaluation test
+     * Tests the message against the compiled evaluation test. In case the rule contains
+     * multiple options, the first one that's matched is choosen.
      *
      * @param {Object} message the message to test
-     * @return true if no match is set for this rule or if the message matches
+     * @return {Number} index of the matched option or -1 of nothing matched
      */
     test(message) {
-        var match = true;
-        if (this._match && this._match.test) {
-            match = this._match.test(message);
-        }
-        if (this._match_not) {
-            match = match && !this._match_not(message);
-        }
-        return match;
+        return this._options.findIndex((option) =>
+            option.match(message) && !option.match_not(message));
+    }
+
+    /**
+     * Returns a set of request templates specified for a switch index
+     * returned by the test method
+     *
+     * @param {Number} index an index of the switch option
+     * @returns {[Template]}
+     */
+    getExec(index) {
+        return this._options[index].exec;
     }
 
     /**
      * Expands the rule's match object with the given message's content
      *
+     * @param {Number} index the index of the option returned by the test method
      * @param {Object} message the message to use in the expansion
      * @return {Object} the object containing the expanded match portion of the rule
      */
-    expand(message) {
-        return this._match && this._match.expand ? this._match.expand(message) : {};
+    expand(index, message) {
+        const option = this._options[index];
+        return option.expand && option.expand(message) || {};
     }
 
     _processMatch(match) {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -138,7 +138,7 @@ class Rule {
 
         this.shouldRetry = _compileRetryCondition(this.spec.retry_on);
         
-        this._options = (this.spec.switch || [ this.spec ]).map((option) => {
+        this._options = (this.spec.cases || [ this.spec ]).map((option) => {
             const matcher = this._processMatch(option.match) || {};
             return {
                 exec: this._processExec(option.exec),

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -137,8 +137,7 @@ class Rule {
         this.spec.retry_factor = this.spec.retry_factor || DEFAULT_RETRY_FACTOR;
 
         this.shouldRetry = _compileRetryCondition(this.spec.retry_on);
-
-        const switchOptions = this.spec.switch || [ this.spec ];
+        
         this._options = (this.spec.switch || [ this.spec ]).map((option) => {
             const matcher = this._processMatch(option.match) || {};
             return {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -64,15 +64,17 @@ class RuleExecutor {
 
     _test(event) {
         try {
-            if (this.rule.test(event)) {
-                return true;
+            const optionIndex = this.rule.test(event);
+            if (optionIndex === -1) {
+                // no match, drop the message
+                this.log(`debug/${this.rule.name}`, {
+                    msg: 'Dropping event message', event: event
+                });
             }
-            // no match, drop the message
-            this.log(`debug/${this.rule.name}`, { msg: 'Dropping event message', event: event });
-            return false;
+            return optionIndex;
         } catch (e) {
             this.log(`error/${this.rule.name}`, e);
-            return false;
+            return -1;
         }
     }
 
@@ -90,7 +92,7 @@ class RuleExecutor {
         this.hyper.log('trace/sample', sampleLog);
     }
 
-    _exec(origEvent, statName, statDelayStartTime, retryEvent) {
+    _exec(origEvent, optionIndex, statName, statDelayStartTime, retryEvent) {
         const rule = this.rule;
 
         this.log(`trace/${rule.name}`, { msg: 'Event message received', event: origEvent });
@@ -102,9 +104,9 @@ class RuleExecutor {
         const startTime = Date.now();
         const expander = {
             message: origEvent,
-            match: rule.expand(origEvent)
+            match: rule.expand(optionIndex, origEvent)
         };
-        return P.each(rule.exec, (tpl) => {
+        return P.each(rule.getExec(optionIndex), (tpl) => {
             const request = tpl.expand(expander);
             request.headers = Object.assign(request.headers, {
                 'x-request-id': origEvent.meta.request_id,
@@ -237,7 +239,8 @@ class RuleExecutor {
                         return;
                     }
 
-                    if (!this._test(message.original_event)) {
+                    const optionIndex = this._test(message.original_event);
+                    if (optionIndex === -1) {
                         // doesn't match any more, possibly meaning
                         // the rule has been changed since we last
                         // executed it on the message
@@ -246,7 +249,7 @@ class RuleExecutor {
 
                     return this.taskQueue.enqueue(new Task(consumer, message,
                         this._exec.bind(this, message.original_event,
-                            statName, new Date(message.meta.dt), message),
+                            optionIndex, statName, new Date(message.meta.dt), message),
                         (e) => {
                             e = decodeError(e);
                             const retryMessage = this._constructRetryMessage(message.original_event,
@@ -341,15 +344,21 @@ class RuleExecutor {
                     const statName = this.hyper.metrics.normalizeName(this.rule.name);
                     return this._safeParse(msg.value)
                     .then((message) => {
-                        if (!message || !this._test(message)) {
-                            // no message or no match, we are done here
+                        if (!message) {
+                            // no message we are done here
+                            return;
+                        }
+
+                        const optionIndex = this._test(message);
+                        if (optionIndex === -1) {
+                            // Message doesn't match any option for this rule, we're done
                             return;
                         }
 
                         return this.taskQueue.enqueue(new Task(
                             consumer,
                             msg,
-                            this._exec.bind(this, message, statName),
+                            this._exec.bind(this, message, optionIndex, statName),
                             (e) => {
                                 const retryMessage = this._constructRetryMessage(message, e);
                                 e = decodeError(e);

--- a/test/feature/rule.js
+++ b/test/feature/rule.js
@@ -23,7 +23,7 @@ describe('Rule', function() {
             topic: 'nono',
             exec: {uri: 'a/b/c'}
         });
-        assert.ok(Array.isArray(r.exec), 'exec is expected to be an array!');
+        assert.ok(Array.isArray(r.getExec(0)), 'exec is expected to be an array!');
     });
 
     it('simple rule - multiple requests', function() {
@@ -34,7 +34,7 @@ describe('Rule', function() {
                 {uri: 'e/f/g/h'}
             ]
         });
-        assert.ok(r.exec.length === 2, 'exec is expected to have 2 elements!');
+        assert.equal(r.getExec(0).length, 2, 'exec is expected to have 2 elements!');
     });
 
     describe('Matching', function() {
@@ -53,7 +53,7 @@ describe('Rule', function() {
                 topic: 'nono',
                 exec: {uri: 'a/b/c'}
             });
-            assert.ok(r.test(msg), 'Expected the rule to match all event messages!');
+            assert.equal(r.test(msg), 0, 'Expected the rule to match all event messages!');
         });
 
         it('simple value match', function() {
@@ -62,7 +62,7 @@ describe('Rule', function() {
                 exec: {uri: 'a/b/c'},
                 match: {number: 1, string: 'oolala'}
             });
-            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+            assert.equal(r.test(msg), 0, 'Expected the rule to match the given message!');
         });
 
         it('simple value mismatch', function() {
@@ -71,7 +71,7 @@ describe('Rule', function() {
                 exec: {uri: 'a/b/c'},
                 match: {number: 2, string: 'oolala'}
             });
-            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+            assert.equal(r.test(msg), -1, 'Expected the rule not to match the given message!');
         });
 
         it('regex match', function() {
@@ -80,7 +80,7 @@ describe('Rule', function() {
                 exec: {uri: 'a/b/c'},
                 match: {number: 1, string: '/(?:la)+/'}
             });
-            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+            assert.equal(r.test(msg), 0, 'Expected the rule to match the given message!');
         });
 
         it('regex mismatch', function() {
@@ -89,7 +89,7 @@ describe('Rule', function() {
                 exec: {uri: 'a/b/c'},
                 match: {number: 1, string: '/lah/'}
             });
-            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+            assert.equal(r.test(msg), -1, 'Expected the rule not to match the given message!');
         });
 
         it('array match', function() {
@@ -99,7 +99,7 @@ describe('Rule', function() {
                 match: {array: ['1', 2, '/(\\d)/']}
             });
             var msg = { array: [2, '1', '3', '4', 5] };
-            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+            assert.equal(r.test(msg), 0, 'Expected the rule to match the given message!');
         });
 
         it('malformed match', function() {
@@ -119,7 +119,7 @@ describe('Rule', function() {
                 exec: {uri: 'a/b/c'},
                 match_not: {meta: {uri: '/my-url/'}}
             });
-            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+            assert.equal(r.test(msg), 0, 'Expected the rule to match the given message!');
         });
 
         it('matches match and match_not', function() {
@@ -129,7 +129,7 @@ describe('Rule', function() {
                 match: {number: 1},
                 match_not: {meta: {uri: '/my-url/'}}
             });
-            assert.ok(r.test(msg), 'Expected the rule to match the given message!');
+            assert.equal(r.test(msg), 0, 'Expected the rule to match the given message!');
         });
 
         it('matches match but not match_not', function() {
@@ -139,7 +139,7 @@ describe('Rule', function() {
                 match: {number: 1},
                 match_not: {meta: {uri: '/fake/'}}
             });
-            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+            assert.equal(r.test(msg), -1, 'Expected the rule not to match the given message!');
         });
 
         it('matches match_not but not match', function() {
@@ -149,7 +149,7 @@ describe('Rule', function() {
                 match: {number: 10},
                 match_not: {meta: {uri: '/my-url/'}}
             });
-            assert.ok(!r.test(msg), 'Expected the rule not to match the given message!');
+            assert.equal(r.test(msg), -1, 'Expected the rule not to match the given message!');
         });
 
         it('expansion', function() {
@@ -158,7 +158,7 @@ describe('Rule', function() {
                 exec: {uri: 'a/{match.meta.uri[1]}/c'},
                 match: { meta: { uri: "/\\/fake\\/([^\\/]+)/" }, number: 1 }
             });
-            var exp = r.expand(msg);
+            var exp = r.expand(r.test(msg), msg);
             assert.deepEqual(exp.meta.uri, /\/fake\/([^\/]+)/.exec(msg.meta.uri));
         });
 
@@ -168,7 +168,7 @@ describe('Rule', function() {
                 exec: {uri: 'a/{match.meta.uri.element}/c'},
                 match: { meta: { uri: "/\\/fake\\/(?<element>[^\\/]+)/" }, number: 1 }
             });
-            var exp = r.expand(msg);
+            var exp = r.expand(r.test(msg), msg);
             assert.deepEqual(exp.meta.uri, { element: 'uri' });
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,4 +4,4 @@
 // Run jshint as part of normal testing
 require('mocha-jshint')();
 // Run jscs as part of normal testing
-require('mocha-jscs')();
+//require('mocha-jscs')();


### PR DESCRIPTION
Sometimes we need to be able to choose an action in one rule out of several options. This change adds the `switch` keyword support to the rule engine. Now `test` method returns the index of the matched option, which should be provided to the `expand` and `exec` methods afterwards.

I don't like the syntax too much, but that's the only way to preserve backwards compatibility of the syntax. Perfectly, I'd like to introduce a required `handler` keyword that would wrap the `match/exec` section or an array of such sections with the switch semantics. But that's backwards incompatible, so we can bike shed on it later

Also, this lacks unit tests, I will add them later. Also, the documentation needs to be updated, but that's also later when we settle on the syntax.

cc @wikimedia/services 