### PR TITLE
Support ignoring errors

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -144,6 +144,10 @@ services:
 
                     null_edit:
                       topic: resource_change
+                      ignore:
+                        # Ignoring 403 since some of the pages with high number of null_edit events are blacklisted
+                        - 403
+                        - 412
                       match:
                         meta:
                           uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
@@ -182,6 +186,9 @@ services:
 
                     page_delete:
                       topic: mediawiki.page_delete
+                      ignore:
+                        - 404 # 404 is a normal response for page deletion
+                        - 412
                       exec:
                         method: get
                         uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.title}'

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -14,7 +14,7 @@ const DEFAULT_RETRY_LIMIT = 2;      // At most two retries
  * @param retryDefinition the condition in the format of 'retry_on' stanza
  * @returns {Function} a function that verifies the condition
  */
-function _compileRetryCondition(retryDefinition) {
+function _compileErrorCheckCondition(retryDefinition) {
     function createCondition(retryCond, option) {
         if (retryCond === 'status') {
             const opt = option.toString();
@@ -132,12 +132,16 @@ class Rule {
         this.spec.retry_on = this.spec.retry_on || {
             status: [ '50x' ]
         };
+        this.spec.ignore = this.spec.ignore || {
+            status: [ 412 ]
+        };
         this.spec.retry_delay = this.spec.retry_delay || DEFAULT_RETRY_DELAY;
         this.spec.retry_limit = this.spec.retry_limit || DEFAULT_RETRY_LIMIT;
         this.spec.retry_factor = this.spec.retry_factor || DEFAULT_RETRY_FACTOR;
 
-        this.shouldRetry = _compileRetryCondition(this.spec.retry_on);
-        
+        this.shouldRetry = _compileErrorCheckCondition(this.spec.retry_on);
+        this.shouldIgnoreError = _compileErrorCheckCondition(this.spec.ignore);
+
         this._options = (this.spec.cases || [ this.spec ]).map((option) => {
             const matcher = this._processMatch(option.match) || {};
             return {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -189,6 +189,11 @@ class RuleExecutor {
     }
 
     _catch(message, retryMessage, e) {
+        const reportError = () => this.hyper.post({
+            uri: '/sys/queue/events',
+            body: [this._constructErrorMessage(e, message)]
+        });
+
         if (e.constructor.name !== 'HTTPError') {
             // We've got an error, but it's not from the update request, it's
             // some bug in change-prop. Log and send a fatal error message.
@@ -197,14 +202,13 @@ class RuleExecutor {
                 error: e,
                 event: message
             });
+            return reportError();
         } else if (this.rule.shouldRetry(e)
             && !this._isLimitExceeded(retryMessage, e)) {
             return this._retry(retryMessage);
+        } else if (!this.rule.shouldIgnoreError(e)) {
+            return reportError();
         }
-        return this.hyper.post({
-            uri: '/sys/queue/events',
-            body: [this._constructErrorMessage(e, message)]
-        });
     }
 
     /**

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -407,5 +407,48 @@ describe('Basic rule management', function() {
         });
     });
 
+    it('Should not emit messages to error topic if ignore condition was met', (done) => {
+        let finished = false;
+        const service = nock('http://mock.com', {
+            reqheaders: {
+                test_header_name: 'test_header_value',
+                'content-type': 'application/json',
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'ChangePropTestSuite'
+            }
+        })
+        .post('/', {
+            'test_field_name': 'test_field_value',
+            'derived_field': 'test'
+        })
+        .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
+        .reply(412, {});
+
+        kafkaFactory.newConsumer(kafkaFactory.newClient(),
+            'change-prop.error',
+            'change-prop-test-error-consumer')
+        .then((errorConsumer) => {
+            errorConsumer.once('message', (message) => {
+                if (!finished) {
+                    done(new Error('Error should have been ignored'))
+                }
+            });
+        })
+        .then(() => {
+            return producer.sendAsync([{
+                topic: 'test_dc.simple_test_rule',
+                messages: [ JSON.stringify(common.eventWithMessage('test')) ]
+            }])
+            .delay(common.REQUEST_CHECK_DELAY)
+            .then(() => service.done())
+            .finally(() => {
+                nock.cleanAll();
+                if (!finished) {
+                    done();
+                }
+            });
+        });
+    });
+
     after(() => changeProp.stop());
 });

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -430,6 +430,7 @@ describe('Basic rule management', function() {
         .then((errorConsumer) => {
             errorConsumer.once('message', (message) => {
                 if (!finished) {
+                    finished = true;
                     done(new Error('Error should have been ignored'))
                 }
             });
@@ -444,6 +445,7 @@ describe('Basic rule management', function() {
             .finally(() => {
                 nock.cleanAll();
                 if (!finished) {
+                    finished = true;
                     done();
                 }
             });


### PR DESCRIPTION
We need to support ignoring certain types of errors, for example 412 that means the content has already been rerendered before CP got to it.

cc @wikimedia/services