### PR TITLE
Restructure config so that indentation matches puppet

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -1,3 +1,355 @@
+spec: &spec
+  x-sub-request-filters:
+    - type: default
+      name: http
+      options:
+        allow:
+          - pattern: /^https?:\/\//
+            forward_headers:
+              user-agent: true
+  title: The Change Propagation root
+  paths:
+    /sys/purge:
+      x-modules:
+        - path: sys/purge.js
+          options:
+            host: 127.0.0.1
+            port: 4321
+    /sys/links:
+      x-modules:
+        - path: sys/dep_updates.js
+          options:
+            templates:
+              mw_api:
+                  uri: 'https://{{message.meta.domain}}/w/api.php'
+                  headers:
+                    host: '{{message.meta.domain}}'
+                  body:
+                    formatversion: 2
+    /sys/queue:
+      x-modules:
+        - path: sys/kafka.js
+          options:
+            uri: 127.0.0.1:2181
+            dc_name: test_dc
+            concurrency: 250
+            templates:
+
+              summary_rerender:
+                topic: resource_change
+                retry_limit: 2
+                retry_delay: 500
+                retry_on:
+                  status:
+                    - '5xx'
+                match:
+                  meta:
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
+                  tags:
+                    - restbase
+                match_not:
+                  meta:
+                    domain: '/wiktionary.org$/'
+                exec:
+                  method: get
+                  # Don't encode title since it should be already encoded
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
+                  query:
+                    redirect: false
+                  headers:
+                    cache-control: no-cache
+
+              definition_rerender:
+                topic: resource_change
+                retry_limit: 2
+                retry_delay: 500
+                retry_on:
+                  status:
+                    - '5xx'
+                match:
+                  meta:
+                    # These URIs are coming from RESTBase, so we know that article titles will be normalized
+                    # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A).)+)$/'
+                    domain: '/^en.wiktionary.org$/'
+                  tags:
+                    - restbase
+                exec:
+                  method: get
+                  # Don't encode title since it should be already encoded
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri.title}}'
+                  query:
+                    redirect: false
+                  headers:
+                    cache-control: no-cache
+
+              mobile_rerender:
+                topic: resource_change
+                retry_limit: 2
+                retry_delay: 500
+                retry_on:
+                  status:
+                    - '5xx'
+                match:
+                  meta:
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
+                exec:
+                  method: get
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
+                  query:
+                    redirect: false
+                  headers:
+                    cache-control: no-cache
+
+              purge_varnish:
+                topic: resource_change
+                match:
+                  meta:
+                    uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(?<title>.+)$/'
+                  tags:
+                    - restbase
+                exec:
+                  method: post
+                  uri: '/sys/purge/'
+                  body:
+                    - meta:
+                        uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri.title}}'
+
+              # RESTBase update jobs
+              mw_purge:
+                topic: resource_change
+                match:
+                  meta:
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
+                  tags:
+                    - purge
+                exec:
+                  method: get
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
+                    if-unmodified-since: '{{date(message.meta.dt)}}'
+                  query:
+                    redirect: false
+
+              null_edit:
+                topic: resource_change
+                ignore:
+                  # Ignoring 403 since some of the pages with high number of null_edit events are blacklisted
+                  - 403
+                  - 412
+                match:
+                  meta:
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
+                  tags:
+                    - null_edit
+                exec:
+                  method: get
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
+                    if-unmodified-since: '{{date(message.meta.dt)}}'
+                  query:
+                    redirect: false
+
+              page_edit:
+                topic: mediawiki.revision_create
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'
+                  headers:
+                    cache-control: no-cache
+                    x-restbase-parentrevision: '{{message.rev_parent_id}}'
+                    if-unmodified-since: '{{date(message.meta.dt)}}'
+                  query:
+                    redirect: false
+
+              revision_visibility_change:
+                topic: mediawiki.revision_visibility_set
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/revision/{{message.revision_id}}'
+                  headers:
+                    cache-control: no-cache
+                  query:
+                    redirect: false
+
+              page_delete:
+                topic: mediawiki.page_delete
+                ignore:
+                  - 404 # 404 is a normal response for page deletion
+                  - 412
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.title}'
+                  headers:
+                    cache-control: no-cache
+                  query:
+                    redirect: false
+
+              page_restore:
+                topic: mediawiki.page_restore
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.title}'
+                  headers:
+                    cache-control: no-cache
+                  query:
+                    redirect: false
+
+              page_move:
+                topic: mediawiki.page_move
+                exec:
+                  - method: get
+                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.old_title}'
+                    headers:
+                      cache-control: no-cache
+                    query:
+                      redirect: false
+                  - method: get
+                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.new_title}/{{message.new_revision_id}}'
+                    headers:
+                      cache-control: no-cache
+                      if-unmodified-since: '{{date(message.meta.dt)}}'
+                    query:
+                      redirect: false
+
+              transclusion_update:
+                topic: mediawiki.revision_create
+                exec:
+                  method: 'post'
+                  uri: '/sys/links/transcludes/{{message.page_title}}'
+                  body: '{{globals.message}}'
+
+              transclusion_updates:
+                topic: resource_change
+                match:
+                  meta:
+                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+                  tags: [ 'change-prop', 'transcludes' ]
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
+                  query:
+                    redirect: false
+
+              # ORES caching updates
+              ores_cache:
+                topic: mediawiki.revision_create
+                concurrency: 10
+                cases:
+                  - match:
+                      meta:
+                        domain: ar.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/arwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: en.wikipedia.org
+                    exec:
+                      - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/damaging/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/reverted/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/goodfaith/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: es.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/eswiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: et.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/etwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: fa.wikipedia.org
+                    exec:
+                      - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/damaging/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/reverted/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/goodfaith/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: fr.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/frwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: he.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/hewiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: hu.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/huwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: id.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/idwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: it.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/itwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: nl.wikipedia.org
+                    exec:
+                      - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/damaging/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/reverted/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/goodfaith/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: pl.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/plwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: pt.wikipedia.org
+                    exec:
+                      - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/damaging/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/reverted/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/goodfaith/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: test.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/testwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: ru.wikipedia.org
+                    exec:
+                      - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/damaging/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/reverted/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/goodfaith/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: tr.wikipedia.org
+                    exec:
+                      - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/damaging/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/reverted/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/goodfaith/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: uk.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/ukwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: vi.wikipedia.org
+                    exec:
+                      uri: 'https://ores.wikimedia.org/v2/scores/viwiki/reverted/{{message.rev_id}}/?precache=true'
+                  - match:
+                      meta:
+                        domain: wikidata.org
+                    exec:
+                      - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/damaging/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/reverted/{{message.rev_id}}/?precache=true'
+                      - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/goodfaith/{{message.rev_id}}/?precache=true'
+
 num_workers: 0
 logging:
   name: changeprop
@@ -8,354 +360,4 @@ services:
     conf:
       port: 7272
       user_agent: SampleChangePropInstance
-      spec:
-        x-sub-request-filters:
-          - type: default
-            name: http
-            options:
-              allow:
-                - pattern: /^https?:\/\//
-                  forward_headers:
-                    user-agent: true
-        title: The Change Propagation root
-        paths:
-          /sys/purge:
-            x-modules:
-              - path: sys/purge.js
-                options:
-                  host: 127.0.0.1
-                  port: 4321
-          /sys/links:
-            x-modules:
-              - path: sys/dep_updates.js
-                options:
-                  templates:
-                    mw_api:
-                        uri: 'https://{{message.meta.domain}}/w/api.php'
-                        headers:
-                          host: '{{message.meta.domain}}'
-                        body:
-                          formatversion: 2
-          /sys/queue:
-            x-modules:
-              - path: sys/kafka.js
-                options:
-                  uri: 127.0.0.1:2181
-                  dc_name: test_dc
-                  concurrency: 250
-                  templates:
-
-                    summary_rerender:
-                      topic: resource_change
-                      retry_limit: 2
-                      retry_delay: 500
-                      retry_on:
-                        status:
-                          - '5xx'
-                      match:
-                        meta:
-                          uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
-                        tags:
-                          - restbase
-                      match_not:
-                        meta:
-                          domain: '/wiktionary.org$/'
-                      exec:
-                        method: get
-                        # Don't encode title since it should be already encoded
-                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
-                        query:
-                          redirect: false
-                        headers:
-                          cache-control: no-cache
-
-                    definition_rerender:
-                      topic: resource_change
-                      retry_limit: 2
-                      retry_delay: 500
-                      retry_on:
-                        status:
-                          - '5xx'
-                      match:
-                        meta:
-                          # These URIs are coming from RESTBase, so we know that article titles will be normalized
-                          # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
-                          uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A).)+)$/'
-                          domain: '/^en.wiktionary.org$/'
-                        tags:
-                          - restbase
-                      exec:
-                        method: get
-                        # Don't encode title since it should be already encoded
-                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri.title}}'
-                        query:
-                          redirect: false
-                        headers:
-                          cache-control: no-cache
-
-                    mobile_rerender:
-                      topic: resource_change
-                      retry_limit: 2
-                      retry_delay: 500
-                      retry_on:
-                        status:
-                          - '5xx'
-                      match:
-                        meta:
-                          uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
-                      exec:
-                        method: get
-                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
-                        query:
-                          redirect: false
-                        headers:
-                          cache-control: no-cache
-
-                    purge_varnish:
-                      topic: resource_change
-                      match:
-                        meta:
-                          uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(?<title>.+)$/'
-                        tags:
-                          - restbase
-                      exec:
-                        method: post
-                        uri: '/sys/purge/'
-                        body:
-                          - meta:
-                              uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri.title}}'
-
-                    # RESTBase update jobs
-                    mw_purge:
-                      topic: resource_change
-                      match:
-                        meta:
-                          uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
-                        tags:
-                          - purge
-                      exec:
-                        method: get
-                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-                        headers:
-                          cache-control: no-cache
-                          if-unmodified-since: '{{date(message.meta.dt)}}'
-                        query:
-                          redirect: false
-
-                    null_edit:
-                      topic: resource_change
-                      ignore:
-                        # Ignoring 403 since some of the pages with high number of null_edit events are blacklisted
-                        - 403
-                        - 412
-                      match:
-                        meta:
-                          uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
-                        tags:
-                          - null_edit
-                      exec:
-                        method: get
-                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-                        headers:
-                          cache-control: no-cache
-                          if-unmodified-since: '{{date(message.meta.dt)}}'
-                        query:
-                          redirect: false
-
-                    page_edit:
-                      topic: mediawiki.revision_create
-                      exec:
-                        method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'
-                        headers:
-                          cache-control: no-cache
-                          x-restbase-parentrevision: '{{message.rev_parent_id}}'
-                          if-unmodified-since: '{{date(message.meta.dt)}}'
-                        query:
-                          redirect: false
-
-                    revision_visibility_change:
-                      topic: mediawiki.revision_visibility_set
-                      exec:
-                        method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/revision/{{message.revision_id}}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
-
-                    page_delete:
-                      topic: mediawiki.page_delete
-                      ignore:
-                        - 404 # 404 is a normal response for page deletion
-                        - 412
-                      exec:
-                        method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.title}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
-
-                    page_restore:
-                      topic: mediawiki.page_restore
-                      exec:
-                        method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.title}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
-
-                    page_move:
-                      topic: mediawiki.page_move
-                      exec:
-                        - method: get
-                          uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.old_title}'
-                          headers:
-                            cache-control: no-cache
-                          query:
-                            redirect: false
-                        - method: get
-                          uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.new_title}/{{message.new_revision_id}}'
-                          headers:
-                            cache-control: no-cache
-                            if-unmodified-since: '{{date(message.meta.dt)}}'
-                          query:
-                            redirect: false
-
-                    transclusion_update:
-                      topic: mediawiki.revision_create
-                      exec:
-                        method: 'post'
-                        uri: '/sys/links/transcludes/{{message.page_title}}'
-                        body: '{{globals.message}}'
-
-                    transclusion_updates:
-                      topic: resource_change
-                      match:
-                        meta:
-                          uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
-                        tags: [ 'change-prop', 'transcludes' ]
-                      exec:
-                        method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
-
-                    # ORES caching updates
-                    ores_cache:
-                      topic: mediawiki.revision_create
-                      concurrency: 10
-                      cases:
-                        - match:
-                            meta:
-                              domain: ar.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/arwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: en.wikipedia.org
-                          exec:
-                            - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/damaging/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/reverted/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/goodfaith/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: es.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/eswiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: et.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/etwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: fa.wikipedia.org
-                          exec:
-                            - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/damaging/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/reverted/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/goodfaith/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: fr.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/frwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: he.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/hewiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: hu.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/huwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: id.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/idwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: it.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/itwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: nl.wikipedia.org
-                          exec:
-                            - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/damaging/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/reverted/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/goodfaith/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: pl.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/plwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: pt.wikipedia.org
-                          exec:
-                            - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/damaging/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/reverted/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/goodfaith/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: test.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/testwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: ru.wikipedia.org
-                          exec:
-                            - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/damaging/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/reverted/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/goodfaith/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: tr.wikipedia.org
-                          exec:
-                            - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/damaging/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/reverted/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/goodfaith/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: uk.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/ukwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: vi.wikipedia.org
-                          exec:
-                            uri: 'https://ores.wikimedia.org/v2/scores/viwiki/reverted/{{message.rev_id}}/?precache=true'
-                        - match:
-                            meta:
-                              domain: wikidata.org
-                          exec:
-                            - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/damaging/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/reverted/{{message.rev_id}}/?precache=true'
-                            - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/goodfaith/{{message.rev_id}}/?precache=true'
+      spec: *spec

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -1,3 +1,107 @@
+spec: &spec
+  x-sub-request-filters:
+    - type: default
+      name: http
+      options:
+        allow:
+          - pattern: /^https?:\/\//
+            forward_headers:
+              user-agent: true
+  title: The Change Propagation root
+  paths:
+    /sys/links:
+      x-modules:
+        - path: sys/dep_updates.js
+          options:
+            templates:
+              mw_api:
+                  uri: 'https://{{message.meta.domain}}/w/api.php'
+                  headers:
+                    host: '{{message.meta.domain}}'
+                  body:
+                    formatversion: 2
+    /sys/queue:
+      x-modules:
+        - path: sys/kafka.js
+          options:
+            uri: 127.0.0.1:2181
+            consume_dc: test_dc
+            produce_dc: test_dc
+            concurrency: 1
+            templates:
+              simple_test_rule:
+                topic: simple_test_rule
+                retry_limit: 2
+                retry_delay: 10
+                retry_on:
+                  status:
+                    - '50x'
+                    - 400
+                match:
+                  meta:
+                    uri: '/sample/uri'
+                  message: 'test'
+                exec:
+                  method: post
+                  uri: 'http://mock.com'
+                  headers:
+                    test_header_name: test_header_value
+                    content-type: application/json
+                  body:
+                    test_field_name: test_field_value
+                    derived_field: '{{message.message}}'
+                    random_field: '{{message.random}}'
+              redirect_testing_rule:
+                topic: simple_test_rule
+                match:
+                  meta:
+                    uri: '/sample/uri'
+                  message: 'redirect'
+                exec:
+                  method: get
+                  uri: 'http://mock.com/will_redirect'
+
+              process_redlinks:
+                topic: mediawiki.revision_create
+                retry_limit: 0
+                match:
+                  rev_parent_id: undefined
+                exec:
+                  method: post
+                  uri: '/sys/links/backlinks/{message.title}'
+                  body: '{{globals.message}}'
+
+              rerender_restbase:
+                topic: resource_change
+                match:
+                  meta:
+                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+                  tags: [ 'change-prop', 'backlinks' ]
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
+
+              kafka_producing_rule:
+                topic: kafka_producing_rule
+                exec:
+                  method: 'post'
+                  uri: '/sys/queue/events'
+                  body:
+                    - meta:
+                        topic: '{{message.produce_to_topic}}'
+                        uri: '{{message.meta.uri}}'
+                        request_id: '{{message.meta.request_id}}'
+                      message: 'test'
+                      triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
+                    - meta:
+                        topic: '{{message.produce_to_topic}}'
+                        uri: '{{message.meta.uri}}'
+                        request_id: '{{message.meta.request_id}}'
+                      message: 'test'
+                      triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
+
 num_workers: 0
 logging:
   name: changeprop
@@ -8,107 +112,4 @@ services:
     conf:
       user_agent: ChangePropTestSuite
       port: 7272
-      spec:
-        x-sub-request-filters:
-          - type: default
-            name: http
-            options:
-              allow:
-                - pattern: /^https?:\/\//
-                  forward_headers:
-                    user-agent: true
-        title: The Change Propagation root
-        paths:
-          /sys/links:
-            x-modules:
-              - path: sys/dep_updates.js
-                options:
-                  templates:
-                    mw_api:
-                        uri: 'https://{{message.meta.domain}}/w/api.php'
-                        headers:
-                          host: '{{message.meta.domain}}'
-                        body:
-                          formatversion: 2
-          /sys/queue:
-            x-modules:
-              - path: sys/kafka.js
-                options:
-                  uri: 127.0.0.1:2181
-                  consume_dc: test_dc
-                  produce_dc: test_dc
-                  concurrency: 1
-                  templates:
-                    simple_test_rule:
-                      topic: simple_test_rule
-                      retry_limit: 2
-                      retry_delay: 10
-                      retry_on:
-                        status:
-                          - '50x'
-                          - 400
-                      match:
-                        meta:
-                          uri: '/sample/uri'
-                        message: 'test'
-                      exec:
-                        method: post
-                        uri: 'http://mock.com'
-                        headers:
-                          test_header_name: test_header_value
-                          content-type: application/json
-                        body:
-                          test_field_name: test_field_value
-                          derived_field: '{{message.message}}'
-                          random_field: '{{message.random}}'
-
-                    redirect_testing_rule:
-                      topic: simple_test_rule
-                      match:
-                        meta:
-                          uri: '/sample/uri'
-                        message: 'redirect'
-                      exec:
-                        method: get
-                        uri: 'http://mock.com/will_redirect'
-
-                    process_redlinks:
-                      topic: mediawiki.revision_create
-                      retry_limit: 0
-                      match:
-                        rev_parent_id: undefined
-                      exec:
-                        method: post
-                        uri: '/sys/links/backlinks/{message.title}'
-                        body: '{{globals.message}}'
-
-                    rerender_restbase:
-                      topic: resource_change
-                      match:
-                        meta:
-                          uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
-                        tags: [ 'change-prop', 'backlinks' ]
-                      exec:
-                        method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-                        headers:
-                          cache-control: no-cache
-
-                    kafka_producing_rule:
-                      topic: kafka_producing_rule
-                      exec:
-                        method: 'post'
-                        uri: '/sys/queue/events'
-                        body:
-                          - meta:
-                              topic: '{{message.produce_to_topic}}'
-                              uri: '{{message.meta.uri}}'
-                              request_id: '{{message.meta.request_id}}'
-                            message: 'test'
-                            triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
-                          - meta:
-                              topic: '{{message.produce_to_topic}}'
-                              uri: '{{message.meta.uri}}'
-                              request_id: '{{message.meta.request_id}}'
-                            message: 'test'
-                            triggered_by: '{{message.meta.topic}}:{{message.meta.uri}}'
+      spec: *spec


### PR DESCRIPTION
I am constantly messing up with indentation when I'm copy-pasting the config changes from here to puppet. It's time to take a radical measures and restructure the config so that the indentations match puppet.

cc @wikimedia/services 