### PR TITLE
Support per-rule concurrency settings

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -248,6 +248,7 @@ services:
                     # ORES caching updates
                     ores_cache:
                       topic: mediawiki.revision_create
+                      concurrency: 10
                       cases:
                         - match:
                             meta:

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -6,6 +6,15 @@ const HTTPError = require('hyperswitch').HTTPError;
 const TopicsNotExistError = require('wmf-kafka-node/lib/errors').TopicsNotExistError;
 const Task = require('./task');
 const utils = require('./utils');
+const TaskQueue = require('../lib/task_queue');
+
+/**
+ * The default size of the task queue
+ *
+ * @type {number}
+ * @const
+ */
+const DEFAULT_TASK_QUEUE_SIZE = 30;
 
 function decodeError(e) {
     if (Buffer.isBuffer(e.body)) {
@@ -32,12 +41,14 @@ class RuleExecutor {
      * @param {function} log
      * @constructor
      */
-    constructor(rule, kafkaFactory, taskQueue, hyper, log) {
+    constructor(rule, kafkaFactory, hyper, log, options) {
         this.rule = rule;
         this.kafkaFactory = kafkaFactory;
-        this.taskQueue = taskQueue;
         this.hyper = hyper;
         this.log = log;
+        this.taskQueue = new TaskQueue({
+            size: rule.spec.concurrency || options.concurrency || DEFAULT_TASK_QUEUE_SIZE
+        });
     }
 
     _setConsumerLoggers(consumer, ruleName, topic) {


### PR DESCRIPTION
For ORES we need to lower the concurrency even more, so add support for per-rule concurrency settings.

Now we have a separate TaskQueue per rule, managing both the normal and retry topic.

cc @wikimedia/services 