### PR TITLE
Decode error before constructing a retry message

### DIFF
--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -364,8 +364,8 @@ class RuleExecutor {
                             msg,
                             this._exec.bind(this, message, optionIndex, statName),
                             (e) => {
-                                const retryMessage = this._constructRetryMessage(message, e);
                                 e = decodeError(e);
+                                const retryMessage = this._constructRetryMessage(message, e);
                                 return this._catch(message, retryMessage, e);
                             }
                         ));


### PR DESCRIPTION
Obvious and simple bug

cc @wikimedia/services 