### PR TITLE
Improve matching function

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -114,7 +114,11 @@ function _compileMatch(obj, result, name, fieldName) {
     const test = Object.keys(obj).map(
         (key) => {
             const propertyName = `${name}['${key}']`;
-            return propertyName + ' && ' + _compileMatch(obj[key], subObj, propertyName, key);
+            if (obj[key].constructor === Object) {
+                return propertyName + ' && ' + _compileMatch(obj[key], subObj, propertyName, key);
+            } else {
+                return _compileMatch(obj[key], subObj, propertyName, key);
+            }
         })
     .join(' && ');
     if (fieldName) {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -112,7 +112,10 @@ function _compileMatch(obj, result, name, fieldName) {
     // this is an object, we need to split it into components
     const subObj = fieldName ? {} : result;
     const test = Object.keys(obj).map(
-        (key) => _compileMatch(obj[key], subObj, `${name}['${key}']`, key))
+        (key) => {
+            const propertyName = `${name}['${key}']`;
+            return propertyName + ' && ' + _compileMatch(obj[key], subObj, propertyName, key);
+        })
     .join(' && ');
     if (fieldName) {
         result[fieldName] = subObj;


### PR DESCRIPTION
While rewriting change-prop to use a new driver I've noticed that sometimes our match function throws an exception since for the long list on nested properties we don't check whether all the objects along the way exist, so we get `Can't read property X of undefined` errors. 

It's not a big issue in production since we catch those errors and treat them as not-match, but it's better to fix anyway.

cc @wikimedia/services 