### PR TITLE
ORES: Filter out edits made by bots

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -243,16 +243,19 @@ spec: &spec
                   - match:
                       meta:
                         domain: ar.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/arwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: cs.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/cswiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: en.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/enwiki/reverted/{{message.rev_id}}/?precache=true'
@@ -260,21 +263,25 @@ spec: &spec
                   - match:
                       meta:
                         domain: en.wiktionary.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/enwiktionary/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: es.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/eswiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: et.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/etwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: fa.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/fawiki/reverted/{{message.rev_id}}/?precache=true'
@@ -282,31 +289,37 @@ spec: &spec
                   - match:
                       meta:
                         domain: fr.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/frwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: he.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/hewiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: hu.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/huwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: id.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/idwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: it.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/itwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: nl.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/reverted/{{message.rev_id}}/?precache=true'
@@ -314,6 +327,7 @@ spec: &spec
                   - match:
                       meta:
                         domain: pl.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/plwiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/plwiki/goodfaith/{{message.rev_id}}/?precache=true'
@@ -321,6 +335,7 @@ spec: &spec
                   - match:
                       meta:
                         domain: pt.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/reverted/{{message.rev_id}}/?precache=true'
@@ -328,6 +343,7 @@ spec: &spec
                   - match:
                       meta:
                         domain: ru.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/reverted/{{message.rev_id}}/?precache=true'
@@ -335,6 +351,7 @@ spec: &spec
                   - match:
                       meta:
                         domain: tr.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/trwiki/reverted/{{message.rev_id}}/?precache=true'
@@ -342,17 +359,20 @@ spec: &spec
                   - match:
                       meta:
                         domain: uk.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/ukwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: vi.wikipedia.org
+                      rev_by_bot: false
                     exec:
                       uri: 'https://ores.wikimedia.org/v2/scores/viwiki/reverted/{{message.rev_id}}/?precache=true'
                   - match:
                       meta:
                         domain: wikidata.org
                       page_namespace: 0
+                      rev_by_bot: false
                     exec:
                       - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/damaging/{{message.rev_id}}/?precache=true'
                       - uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/reverted/{{message.rev_id}}/?precache=true'

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -349,7 +349,8 @@ describe('RESTBase update rules', function() {
                     page_title: 'TestPage',
                     rev_id: 1234,
                     rev_timestamp: new Date().toISOString(),
-                    rev_parent_id: 1233
+                    rev_parent_id: 1233,
+                    rev_by_bot: false
                 })
             ]
         }])


### PR DESCRIPTION
WE need to filter out edits made by bots for ORES preach updates.

Depends on deployment of https://gerrit.wikimedia.org/r/#/c/295500/

cc @Ladsgroup @wikimedia/services 