### PR TITLE
Fix a bug in error ignoring config

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -135,9 +135,9 @@ spec: &spec
               null_edit:
                 topic: resource_change
                 ignore:
-                  # Ignoring 403 since some of the pages with high number of null_edit events are blacklisted
-                  - 403
-                  - 412
+                  status:
+                    - 403 # Ignoring 403 since some of the pages with high number of null_edit events are blacklisted
+                    - 412
                 match:
                   meta:
                     uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
@@ -177,8 +177,9 @@ spec: &spec
               page_delete:
                 topic: mediawiki.page_delete
                 ignore:
-                  - 404 # 404 is a normal response for page deletion
-                  - 412
+                  status:
+                    - 404 # 404 is a normal response for page deletion
+                    - 412
                 exec:
                   method: get
                   uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.title}'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -37,6 +37,10 @@ spec: &spec
                   status:
                     - '50x'
                     - 400
+                ignore:
+                  status:
+                    - 403
+                    - 412
                 match:
                   meta:
                     uri: '/sample/uri'

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -445,7 +445,7 @@ describe('Basic rule management', function() {
             'derived_field': 'test'
         })
         .matchHeader('x-triggered-by', 'simple_test_rule:/sample/uri')
-        .reply(412, {});
+        .reply(403, {});
 
         kafkaFactory.newConsumer(kafkaFactory.newClient(),
             'change-prop.error',


### PR DESCRIPTION
There was an obvious bug in our error ignoring config.

Puppet counterpart: https://gerrit.wikimedia.org/r/#/c/300166/

cc @wikimedia/services 