### PR TITLE
Bug: ignore definition update in reaction to revision change event

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -70,7 +70,7 @@ spec: &spec
                   meta:
                     # These URIs are coming from RESTBase, so we know that article titles will be normalized
                     # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
-                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A).)+)$/'
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A|\/).)+)$/'
                     domain: '/^en.wiktionary.org$/'
                   tags:
                     - restbase


### PR DESCRIPTION
When HTML content changes in RESTBase it emits 2 `resource_change` events: one for title and one for revision. The definition update rule incorrectly reacted to both. The second one treated `title/revision` string as a title and so created an additional request that resolved to 404.

cc @wikimedia/services 