### PR TITLE
Ignore 403 errors on revision_visibility_change

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -154,6 +154,10 @@ spec: &spec
 
               page_edit:
                 topic: mediawiki.revision_create
+                retry_on:
+                  status:
+                    - '5xx'
+                    - 404 # Sometimes occasional 404s happen because of the mysql replication lag, so retry
                 exec:
                   method: get
                   uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -166,6 +166,10 @@ spec: &spec
 
               revision_visibility_change:
                 topic: mediawiki.revision_visibility_set
+                ignore:
+                  status:
+                    - 403 # When the revision is hidden 403 will be returned by RESTBase, it's a valid situation
+                    - 412
                 exec:
                   method: get
                   uri: 'https://{{message.meta.domain}}/api/rest_v1/page/revision/{{message.revision_id}}'


### PR DESCRIPTION
- Obvious: we need to ignore '403' on `revision_visibility_set` event.
- Less obvious: we need to retry '404' response from `revision_create` event. We have quite a few 404 errors in the error topic and I couldn't find any explanation for them except that it's happening due to replication lag in mysql, so let's try to retry these and see what's happening.

cc @wikimedia/services 