### PR TITLE
Reverse the order of page_move updates

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -210,16 +210,16 @@ spec: &spec
                 topic: mediawiki.page_move
                 exec:
                   - method: get
-                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.old_title}'
-                    headers:
-                      cache-control: no-cache
-                    query:
-                      redirect: false
-                  - method: get
                     uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.new_title}/{{message.new_revision_id}}'
                     headers:
                       cache-control: no-cache
                       if-unmodified-since: '{{date(message.meta.dt)}}'
+                    query:
+                      redirect: false
+                  - method: get
+                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.old_title}'
+                    headers:
+                      cache-control: no-cache
                     query:
                       redirect: false
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -396,11 +396,11 @@ describe('RESTBase update rules', function() {
                 'user-agent': 'SampleChangePropInstance'
             }
         })
-        .get('/api/rest_v1/page/title/User%3APchelolo%2FTest')
-        .query({ redirect: false })
-        .reply(200, { })
         .get('/api/rest_v1/page/html/User%3APchelolo%2FTest1/2')
         .matchHeader( 'if-unmodified-since', 'Thu, 01 Jan 1970 00:00:01 +0000')
+        .query({ redirect: false })
+        .reply(200, { })
+        .get('/api/rest_v1/page/title/User%3APchelolo%2FTest')
         .query({ redirect: false })
         .reply(200, { });
 


### PR DESCRIPTION
When a page is moved, the user is able not to create a redirect page. In that case the request to update the older page title results in a 404. However, we don't catch that 404 (and we don't support catching it right now) the `P.each` chain is broken and the new page title is never updated. So, invert the order of the updates would fix this problem.

NOTE: Actually might want to ignore the 404 on this rule, but I didn't add the ignore clause because it's not yet clear to me if all the page_move errors in the error topic are the result of this bug, or if there's some other conditions where the error occurs. So I want to continue monitoring it thus no `ignore` stanza in this PR.
 
cc @wikimedia/services 