### PR TITLE
Stabilise imageupdates test

### DIFF
--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -469,15 +469,8 @@ describe('RESTBase update rules', function() {
     });
 
 
-    it.skip('Should rerender image usages on file update', () => {
+    it('Should rerender image usages on file update', () => {
         const mwAPI = nock('https://en.wikipedia.org')
-        .post('/w/api.php', {
-            format: 'json',
-            action: 'query',
-            meta: 'siteinfo',
-            siprop: 'general|namespaces|namespacealiases'
-        })
-        .reply(200, common.EN_SITE_INFO_RESPONSE)
         .post('/w/api.php', {
             format: 'json',
             action: 'query',


### PR DESCRIPTION
This test was failing all the time - the reason is that the `siteInfo` request shouldn't be mocked - it's fetched for en.wiki in one of the previous tests.

cc @wikimedia/services 