### PR TITLE
Calculate the actual delay based on the message timestamp

### DIFF
--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -21,6 +21,18 @@ class RetryExecutor extends BaseExecutor {
         return `${this.kafkaFactory.consumeDC}.${this._retryTopicName()}`;
     }
 
+    _delay(message) {
+        const spec = this.rule.spec;
+        const absoluteDelay = spec.retry_delay *
+            Math.pow(spec.retry_factor, spec.retry_limit - message.retries_left);
+        const delayFromNow = (Date.parse(message.meta.dt) + absoluteDelay) - Date.now();
+        if (delayFromNow > 0) {
+            return P.delay(delayFromNow);
+        } else {
+            return P.resolve();
+        }
+    }
+
     onMessage(message) {
         if (!message) {
             // Don't retry if we can't parse an event, just log.
@@ -45,11 +57,9 @@ class RetryExecutor extends BaseExecutor {
             return;
         }
 
-        const spec = this.rule.spec;
-        const delay = spec.retry_delay *
-            Math.pow(spec.retry_factor, spec.retry_limit - message.retries_left);
+
         const statName = this.hyper.metrics.normalizeName(this.rule.name + '_retry');
-        return P.delay(delay)
+        return this._delay(message)
         .then(() => this._exec(message.original_event,
             optionIndex, statName, new Date(message.meta.dt), message))
         .catch((e) => {

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -25,6 +25,10 @@ class RetryExecutor extends BaseExecutor {
         const spec = this.rule.spec;
         const absoluteDelay = spec.retry_delay *
             Math.pow(spec.retry_factor, spec.retry_limit - message.retries_left);
+        if (message.meta.dt || !Date.parse(message.meta.dt)) {
+            // No DT on the message, there's nothing we can do
+            return P.delay(absoluteDelay);
+        }
         const delayFromNow = (Date.parse(message.meta.dt) + absoluteDelay) - Date.now();
         if (delayFromNow > 0) {
             return P.delay(delayFromNow);


### PR DESCRIPTION
Delayed messages are counted as executed so are counted in concurrency limit, so backlog grows. 
With this we don't delay messages statically, but instead calculate the actual delay based on when the message was created, not dequeued.

cc @wikimedia/services 