### PR TITLE
Fix race condition in commit logic

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -116,18 +116,21 @@ class BaseExecutor {
 
         if (!this._commitTimeout) {
             this._commitTimeout = setTimeout(() => {
+                this._commitTimeout = null;
                 if (this._toCommit) {
-                    const comitting = this._toCommit;
-                    this._commitTimeout = null;
-                    return this.consumer.commitAsync(comitting)
+                    const committing = this._toCommit;
+                    return this.consumer.commitAsync(committing)
                     .then(() => {
-                        this._toCommit = undefined;
+                        if (this._toCommit.offset === committing.offset) {
+                            // Don't commit what we've just committed
+                            this._toCommit = undefined;
+                        }
                     })
                     .catch((e) => {
                         this.log(`error/commit/${this.rule.name}`, {
                             msg: 'Commit failed',
-                            offset: comitting.offset,
-                            event: comitting.message.toString(),
+                            offset: committing.offset,
+                            event: committing.message.toString(),
                             error: e
                         });
                     });

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -25,7 +25,7 @@ class RetryExecutor extends BaseExecutor {
         const spec = this.rule.spec;
         const absoluteDelay = spec.retry_delay *
             Math.pow(spec.retry_factor, spec.retry_limit - message.retries_left);
-        if (message.meta.dt || !Date.parse(message.meta.dt)) {
+        if (!message.meta.dt || !Date.parse(message.meta.dt)) {
             // No DT on the message, there's nothing we can do
             return P.delay(absoluteDelay);
         }


### PR DESCRIPTION
It was possible that with unlucky timing the commitTimeout could fire after the `_toCommit` was nullified by the callback of the previous commit, then the `_commitTimeout` was never reset.

cc @wikimedia/services 