### PR TITLE
Ignore 503 from ORES

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -256,6 +256,9 @@ spec: &spec
               ores_cache:
                 topic: mediawiki.revision_create
                 concurrency: 10
+                ignore:
+                  status:
+                    - 503
                 cases:
                   - match:
                       meta:

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -280,13 +280,14 @@ class BaseExecutor {
                 event: message
             });
             return reportError();
-        } else if (this.rule.shouldRetry(e)
-                && !this._isLimitExceeded(retryMessage, e)) {
-            return this.hyper.post({
-                uri: '/sys/queue/events',
-                body: [ retryMessage ]
-            });
         } else if (!this.rule.shouldIgnoreError(e)) {
+            if (this.rule.shouldRetry(e)
+                && !this._isLimitExceeded(retryMessage, e)) {
+                return this.hyper.post({
+                    uri: '/sys/queue/events',
+                    body: [ retryMessage ]
+                });
+            }
             return reportError();
         }
     }


### PR DESCRIPTION
ORES responds with 503 when the server is overloaded, don't make the problem worse by retrying.

@Ladsgroup Do you know any other error codes from ORES that shouldn't be retried?

cc @wikimedia/services 