### PR TITLE
Wikidata: Correctly boolean-ise the `success` flag

### DIFF
--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -88,7 +88,7 @@ function createWikidataTemplate(options) {
             }
         })),
         resourceChangeTag: 'wikidata',
-        shouldProcess: (res) => { return res && res.body && !res.body.success; },
+        shouldProcess: (res) => { return res && res.body && !!res.body.success; },
         extractResults: (res) => {
             const siteLinks = res.body.entities[Object.keys(res.body.entities)[0]].sitelinks;
             return Object.keys(siteLinks).map((siteId) => {

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -424,6 +424,7 @@ describe('RESTBase update rules', function() {
             normalize: 'true'
         })
         .reply(200, {
+            "success": 1,
             "entities": {
                 "Q1": {
                     "type": "item",


### PR DESCRIPTION
The `success` flag in the result of `wbgetentities` is set to `1` if the
query has been successfully executed, so double-negate when checking
whether we should extract the results or not.