### PR TITLE
Wikidata: Make sure we have the response we need to process the deps

### DIFF
--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -88,7 +88,20 @@ function createWikidataTemplate(options) {
             }
         })),
         resourceChangeTag: 'wikidata',
-        shouldProcess: (res) => { return res && res.body && !!res.body.success; },
+        shouldProcess: (res) => {
+            if (!(res && res.body && !!res.body.success)) {
+                return false;
+            }
+            const entities = res.body.entities || {};
+            if (!Object.keys(entities).length) {
+                return false;
+            }
+            const sitelinks = entities[Object.keys(entities)[0]].sitelinks || {};
+            if (!Object.keys(sitelinks).length) {
+                return false;
+            }
+            return true;
+        },
         extractResults: (res) => {
             const siteLinks = res.body.entities[Object.keys(res.body.entities)[0]].sitelinks;
             return Object.keys(siteLinks).map((siteId) => {


### PR DESCRIPTION
While looking at the returned `success` flag tells us whether the query
has been successfully executed, it does not ensure that the response
contains the fields we need to send resource_change events for the
dependencies, so check for them explicitly in the response.