### PR TITLE
Wikidata: Only log Wikibase errors and ignore non-mainspace titles

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -490,6 +490,8 @@ spec: &spec
                 match:
                   meta:
                     domain: www.wikidata.org
+                match_not:
+                  page_title: /:/
                 exec:
                   method: 'post'
                   uri: '/sys/links/wikidata_descriptions'

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -207,10 +207,11 @@ class DependencyProcessor {
                 const items = this.wikidataRequest.extractResults(res);
                 return this._sendResourceChanges(hyper, items, req.body,
                     this.wikidataRequest.resourceChangeTag);
-            } else {
+            } else if (res.body && res.body.error) {
                 this.log('warn/wikidata_description', {
                     msg: 'Could not extract items',
-                    event: context.message
+                    event: context.message,
+                    error: res.body.error
                 });
             }
         })


### PR DESCRIPTION
Two improvements for mild issues seen in production:
- do not log all of the events that do not produce links to WP articles, as not all items are actually linked on a site, just log errors returned by Wikibase
- only wikidata items can have site links, so disregard any non-main namespace titles