### PR TITLE
Encode title before calling transcludes module

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -233,6 +233,11 @@ spec: &spec
 
               transclusion_update:
                 topic: mediawiki.revision_create
+                # Test-only. We use undefined rev_parent_id to test backlinks so we
+                # don't want transclusions to interfere with backlinks test
+                match_not:
+                  rev_parent_id: undefined
+                # end of test-only config
                 exec:
                   method: 'post'
                   uri: '/sys/links/transcludes/{message.page_title}'
@@ -463,27 +468,27 @@ spec: &spec
                         precache: true
 
               # This is not yet used in production
-#              process_redlinks:
-#                topic: mediawiki.revision_create
-#                retry_limit: 0
-#                match:
-#                  rev_parent_id: undefined
-#                exec:
-#                  method: post
-#                  uri: '/sys/links/backlinks/{message.page_title}'
-#                  body: '{{globals.message}}'
-#
-#              rerender_restbase:
-#                topic: resource_change
-#                match:
-#                  meta:
-#                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
-#                  tags: [ 'change-prop', 'backlinks' ]
-#                exec:
-#                  method: get
-#                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-#                  headers:
-#                    cache-control: no-cache
+              process_redlinks:
+                topic: mediawiki.revision_create
+                retry_limit: 0
+                match:
+                  rev_parent_id: undefined
+                exec:
+                  method: post
+                  uri: '/sys/links/backlinks/{message.page_title}'
+                  body: '{{globals.message}}'
+
+              rerender_restbase:
+                topic: resource_change
+                match:
+                  meta:
+                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+                  tags: [ 'change-prop', 'backlinks' ]
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
 
               wikidata_description:
                 topic: mediawiki.revision_create

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -463,27 +463,27 @@ spec: &spec
                         precache: true
 
               # This is not yet used in production
-              process_redlinks:
-                topic: mediawiki.revision_create
-                retry_limit: 0
-                match:
-                  rev_parent_id: undefined
-                exec:
-                  method: post
-                  uri: '/sys/links/backlinks/{message.page_title}'
-                  body: '{{globals.message}}'
-
-              rerender_restbase:
-                topic: resource_change
-                match:
-                  meta:
-                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
-                  tags: [ 'change-prop', 'backlinks' ]
-                exec:
-                  method: get
-                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-                  headers:
-                    cache-control: no-cache
+#              process_redlinks:
+#                topic: mediawiki.revision_create
+#                retry_limit: 0
+#                match:
+#                  rev_parent_id: undefined
+#                exec:
+#                  method: post
+#                  uri: '/sys/links/backlinks/{message.page_title}'
+#                  body: '{{globals.message}}'
+#
+#              rerender_restbase:
+#                topic: resource_change
+#                match:
+#                  meta:
+#                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+#                  tags: [ 'change-prop', 'backlinks' ]
+#                exec:
+#                  method: get
+#                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+#                  headers:
+#                    cache-control: no-cache
 
               wikidata_description:
                 topic: mediawiki.revision_create

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -235,7 +235,7 @@ spec: &spec
                 topic: mediawiki.revision_create
                 exec:
                   method: 'post'
-                  uri: '/sys/links/transcludes/{{message.page_title}}'
+                  uri: '/sys/links/transcludes/{message.page_title}'
                   body: '{{globals.message}}'
 
               transclusion_updates:
@@ -470,7 +470,7 @@ spec: &spec
                   rev_parent_id: undefined
                 exec:
                   method: post
-                  uri: '/sys/links/backlinks/{message.title}'
+                  uri: '/sys/links/backlinks/{message.page_title}'
                   body: '{{globals.message}}'
 
               rerender_restbase:

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -145,7 +145,7 @@ class DependencyProcessor {
                     exec: [
                         {
                             method: 'post',
-                            uri: '/sys/links/backlinks/{message.original_event.title}',
+                            uri: '/sys/links/backlinks/{message.original_event.page_title}',
                             body: '{{globals.message}}'
                         }
                     ]

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -608,7 +608,10 @@ describe('RESTBase update rules', function() {
 
         return producer.produceAsync({
             topic: 'test_dc.mediawiki.revision_create',
-            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', { page_title: 'File:Pchelolo/Test.jpg' }))
+            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', {
+                page_title: 'File:Pchelolo/Test.jpg',
+                rev_parent_id: 12345 // Needed to avoid backlinks updates firing and interfering
+            }))
         })
         .then(() => common.checkAPIDone(mwAPI, 50))
         .finally(() => nock.cleanAll());
@@ -659,7 +662,7 @@ describe('RESTBase update rules', function() {
         });
     });
 
-    it.skip('Should process backlinks', () => {
+    it('Should process backlinks', () => {
         const mwAPI = nock('https://en.wikipedia.org')
         .post('/w/api.php', {
             format: 'json',
@@ -706,7 +709,9 @@ describe('RESTBase update rules', function() {
 
         return producer.produceAsync({
             topic: 'test_dc.mediawiki.revision_create',
-            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', {page_title: 'User:Pchelolo/Test'}))
+            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', {
+                page_title: 'User:Pchelolo/Test'
+            }))
         })
         .then(() => common.checkAPIDone(mwAPI, 50))
         .finally(() => nock.cleanAll());

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -659,7 +659,7 @@ describe('RESTBase update rules', function() {
         });
     });
 
-    it('Should process backlinks', () => {
+    it.skip('Should process backlinks', () => {
         const mwAPI = nock('https://en.wikipedia.org')
         .post('/w/api.php', {
             format: 'json',

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -10,14 +10,14 @@ const assert = require('assert');
 process.env.UV_THREADPOOL_SIZE = 128;
 
 describe('RESTBase update rules', function() {
-    this.timeout(15000);
+    this.timeout(30000);
 
     const changeProp = new ChangeProp('config.example.wikimedia.yaml');
     let producer;
 
     before(function() {
         // Setting up might take some tome, so disable the timeout
-        this.timeout(20000);
+        this.timeout(50000);
         return changeProp.start()
         .then(() =>  common.factory.createProducer())
         .then((result) => producer = result);
@@ -567,7 +567,7 @@ describe('RESTBase update rules', function() {
             format: 'json',
             action: 'query',
             list: 'imageusage',
-            iutitle: 'File:Test.jpg',
+            iutitle: 'File:Pchelolo/Test.jpg',
             iulimit: '500',
             formatversion: '2'
         })
@@ -578,19 +578,19 @@ describe('RESTBase update rules', function() {
                 continue: '-||'
             },
             query: {
-                imageusage: common.arrayWithLinks('Some_Page', 2)
+                imageusage: common.arrayWithLinks('File_Transcluded_Page', 2)
             }
         })
-        .get('/api/rest_v1/page/html/Some_Page')
+        .get('/api/rest_v1/page/html/File_Transcluded_Page')
         .query({redirect: false})
-        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/File_Transcluded_Page')
         .times(2)
         .reply(200)
         .post('/w/api.php', {
             format: 'json',
             action: 'query',
             list: 'imageusage',
-            iutitle: 'File:Test.jpg',
+            iutitle: 'File:Pchelolo/Test.jpg',
             iulimit: '500',
             iucontinue: '1|2272',
             formatversion: '2'
@@ -598,19 +598,19 @@ describe('RESTBase update rules', function() {
         .reply(200, {
             batchcomplete: '',
             query: {
-                imageusage: common.arrayWithLinks('Some_Page', 1)
+                imageusage: common.arrayWithLinks('File_Transcluded_Page', 1)
             }
         })
-        .get('/api/rest_v1/page/html/Some_Page')
+        .get('/api/rest_v1/page/html/File_Transcluded_Page')
         .query({redirect: false})
-        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision_create:/sample/uri,resource_change:https://en.wikipedia.org/wiki/File_Transcluded_Page')
         .reply(200);
 
         return producer.produceAsync({
             topic: 'test_dc.mediawiki.revision_create',
-            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', { page_title: 'File:Test.jpg' }))
+            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', { page_title: 'File:Pchelolo/Test.jpg' }))
         })
-        .then(() => common.checkAPIDone(mwAPI))
+        .then(() => common.checkAPIDone(mwAPI, 50))
         .finally(() => nock.cleanAll());
     });
 
@@ -665,7 +665,7 @@ describe('RESTBase update rules', function() {
             format: 'json',
             action: 'query',
             list: 'backlinks',
-            bltitle: 'Main_Page',
+            bltitle: 'User:Pchelolo/Test',
             blfilterredir: 'nonredirects',
             bllimit: '500',
             formatversion: '2'
@@ -688,7 +688,7 @@ describe('RESTBase update rules', function() {
             format: 'json',
             action: 'query',
             list: 'backlinks',
-            bltitle: 'Main_Page',
+            bltitle: 'User:Pchelolo/Test',
             blfilterredir: 'nonredirects',
             bllimit: '500',
             blcontinue: '1|2272',
@@ -706,9 +706,9 @@ describe('RESTBase update rules', function() {
 
         return producer.produceAsync({
             topic: 'test_dc.mediawiki.revision_create',
-            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', {title: 'Main_Page'}))
+            message: JSON.stringify(common.eventWithProperties('mediawiki.revision_create', {page_title: 'User:Pchelolo/Test'}))
         })
-        .then(() => common.checkAPIDone(mwAPI))
+        .then(() => common.checkAPIDone(mwAPI, 50))
         .finally(() => nock.cleanAll());
     });
 

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -81,12 +81,13 @@ common.EN_SITE_INFO_RESPONSE = {
     }
 };
 
-common.checkAPIDone = (api) => {
+common.checkAPIDone = (api, maxAttempts) => {
+    maxAttempts = maxAttempts || 20;
     let attempts = 0;
     const check = () => {
         if (api.isDone()) {
             return;
-        } else if (attempts++ < 20) {
+        } else if (attempts++ < maxAttempts) {
             return P.delay(500).then(check);
         } else {
             return api.done();


### PR DESCRIPTION
Buggy behaviour of transcludes if page title contains slashes.

Also the rules/tests for backlinks are incorrect, but that's not used in production.

Also skip the backlinks test for now - the transclusions and backlinks tests step on each others feet, so disable backlinks test because it's not used it production.

Also, if siteInfo request failed - don't cache the rejected promise, may be next time it will succeed

cc @wikimedia/services 