### PR TITLE
Don't cache failed siteInfo responce

### DIFF
--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -302,6 +302,11 @@ class DependencyProcessor {
                     namespaces: res.body.query.namespaces,
                     namespacealiases: res.body.query.namespacealiases
                 };
+            })
+            .catch((e) => {
+                hyper.log('error/site_info', e);
+                delete this.siteInfoCache[domain];
+                throw e;
             });
         }
         return this.siteInfoCache[domain];


### PR DESCRIPTION
If the request for siteInfo failed - don't cache the failed response, try again next time

cc @wikimedia/services 