### PR TITLE
Don't count rejected messages against the concurrency limits

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -66,13 +66,17 @@ class BaseExecutor {
         this._consuming = true;
         this.consumer.consumeAsync()
         .then((msg) => {
-            this._pendingMsgs.push(msg);
+            // We're pushing it to pending messages only if it matched so that items
+            // that don't match don't count against the concurrency limit.
 
             // Note: we don't return the promise here since we wanna process messages
             // asynchronously from consuming them to be able to fill up the pendingMsg
             // queue and achieve the level of csoncurrency we want.
             this._safeParse(msg.message.toString('utf8'))
-            .then(this.onMessage.bind(this))
+            .then((message) => this.onMessage(message, () => {
+                // This is called when message passe all tests and about to begin execution
+                this._pendingMsgs.push(msg);
+            }))
             .finally(() => {
                 this._notifyFinished(msg);
                 if (this._pendingMsgs.length < this.concurrency && !this._consuming) {
@@ -357,7 +361,7 @@ class BaseExecutor {
         throw new Error('Abstract');
     }
 
-    onMessage(message) {
+    onMessage(message, onExec) {
         throw new Error('Abstract');
     }
 

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -37,7 +37,7 @@ class RetryExecutor extends BaseExecutor {
         }
     }
 
-    onMessage(message) {
+    onMessage(message, onExec) {
         if (!message) {
             // Don't retry if we can't parse an event, just log.
             return;
@@ -61,6 +61,9 @@ class RetryExecutor extends BaseExecutor {
             return;
         }
 
+        if (onExec) {
+            onExec();
+        }
 
         const statName = this.hyper.metrics.normalizeName(this.rule.name + '_retry');
         return this._delay(message)

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -17,7 +17,7 @@ class RuleExecutor extends BaseExecutor {
         return `${this.kafkaFactory.consumeDC}.${this.rule.topic}`;
     }
 
-    onMessage(message) {
+    onMessage(message, onExec) {
         if (!message) {
             // no message we are done here
             return;
@@ -27,6 +27,10 @@ class RuleExecutor extends BaseExecutor {
         if (optionIndex === -1) {
             // Message doesn't match any option for this rule, we're done
             return;
+        }
+
+        if (onExec) {
+            onExec();
         }
 
         const statName = this.hyper.metrics.normalizeName(this.rule.name);


### PR DESCRIPTION
We only need to count actually processed messages agains the concurrency limit, if the message is rejected - don't push it to the pending queue.

Since we have lot's of rejections this might make us go a bit faster when we need.

cc @wikimedia/services 