### PR TITLE
Create separate processors for transcludes-driven rerenders

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -43,60 +43,49 @@ spec: &spec
             concurrency: 250
             templates:
 
-              summary_rerender: &summary_rerender_spec
+              summary_definition_rerender: &summary_definition_rerender_spec
                 topic: resource_change
                 retry_limit: 2
                 retry_delay: 500
                 retry_on:
                   status:
                     - '5xx'
-                match:
-                  meta:
-                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
-                  tags:
-                    - restbase
-                match_not:
-                  meta:
-                    domain: '/wiktionary.org$/'
-                exec:
-                  method: get
-                  # Don't encode title since it should be already encoded
-                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
-                  query:
-                    redirect: false
-                  headers:
-                    cache-control: no-cache
+                cases: # Non wiktionary domains - rerender summary
+                  - match:
+                      meta:
+                        uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
+                      tags:
+                        - restbase
+                    match_not:
+                      meta:
+                        domain: '/wiktionary.org$/'
+                    exec:
+                      method: get
+                      # Don't encode title since it should be already encoded
+                      uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
+                      query:
+                        redirect: false
+                      headers:
+                        cache-control: no-cache
+                  - match: # Wiktionary domains - rerender definitions
+                      meta:
+                        # These URIs are coming from RESTBase, so we know that article titles will be normalized
+                        # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
+                        uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A|\/).)+)$/'
+                        domain: '/^en.wiktionary.org$/'
+                      tags:
+                        - restbase
+                    exec:
+                      method: get
+                      # Don't encode title since it should be already encoded
+                      uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri.title}}'
+                      query:
+                        redirect: false
+                      headers:
+                        cache-control: no-cache
 
-              summary_rerender_transcludes:
-                <<: *summary_rerender_spec
-                topic: change-prop.transcludes.resource-change
-
-              definition_rerender: &definition_rerender_spec
-                topic: resource_change
-                retry_limit: 2
-                retry_delay: 500
-                retry_on:
-                  status:
-                    - '5xx'
-                match:
-                  meta:
-                    # These URIs are coming from RESTBase, so we know that article titles will be normalized
-                    # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
-                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A|\/).)+)$/'
-                    domain: '/^en.wiktionary.org$/'
-                  tags:
-                    - restbase
-                exec:
-                  method: get
-                  # Don't encode title since it should be already encoded
-                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri.title}}'
-                  query:
-                    redirect: false
-                  headers:
-                    cache-control: no-cache
-
-              definition_rerender_transcludes:
-                <<: *definition_rerender_spec
+              summary_definition_rerender_transcludes:
+                <<: *summary_definition_rerender_spec
                 topic: change-prop.transcludes.resource-change
 
               mobile_rerender: &mobile_rerender_spec

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -123,7 +123,7 @@ spec: &spec
                 <<: *mobile_rerender_spec
                 topic: change-prop.transcludes.resource-change
 
-              purge_varnish:
+              purge_varnish: &purge_varnish_spec
                 topic: resource_change
                 match:
                   meta:
@@ -136,6 +136,10 @@ spec: &spec
                   body:
                     - meta:
                         uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri.title}}'
+
+              purge_varnish_transcludes:
+                <<: *purge_varnish_spec
+                topic: change-prop.transcludes.resource-change
 
               # RESTBase update jobs
               mw_purge:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -67,6 +67,30 @@ spec: &spec
                   headers:
                     cache-control: no-cache
 
+              summary_rerender_transcludes:
+                topic: change-prop.transcludes.resource-change
+                retry_limit: 2
+                retry_delay: 500
+                retry_on:
+                  status:
+                    - '5xx'
+                match:
+                  meta:
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
+                  tags:
+                    - restbase
+                match_not:
+                  meta:
+                    domain: '/wiktionary.org$/'
+                exec:
+                  method: get
+                  # Don't encode title since it should be already encoded
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
+                  query:
+                    redirect: false
+                  headers:
+                    cache-control: no-cache
+
               definition_rerender:
                 topic: resource_change
                 retry_limit: 2
@@ -91,8 +115,52 @@ spec: &spec
                   headers:
                     cache-control: no-cache
 
+              definition_rerender_transcludes:
+                topic: change-prop.transcludes.resource-change
+                retry_limit: 2
+                retry_delay: 500
+                retry_on:
+                  status:
+                    - '5xx'
+                match:
+                  meta:
+                    # These URIs are coming from RESTBase, so we know that article titles will be normalized
+                    # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A|\/).)+)$/'
+                    domain: '/^en.wiktionary.org$/'
+                  tags:
+                    - restbase
+                exec:
+                  method: get
+                  # Don't encode title since it should be already encoded
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri.title}}'
+                  query:
+                    redirect: false
+                  headers:
+                    cache-control: no-cache
+
               mobile_rerender:
                 topic: resource_change
+                retry_limit: 2
+                retry_delay: 500
+                retry_on:
+                  status:
+                    - '5xx'
+                match:
+                  meta:
+                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
+                  tags:
+                    - restbase
+                exec:
+                  method: get
+                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
+                  query:
+                    redirect: false
+                  headers:
+                    cache-control: no-cache
+
+              mobile_rerender_transcludes:
+                topic: change-prop.transcludes.resource-change
                 retry_limit: 2
                 retry_delay: 500
                 retry_on:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -43,7 +43,7 @@ spec: &spec
             concurrency: 250
             templates:
 
-              summary_rerender:
+              summary_rerender: &summary_rerender_spec
                 topic: resource_change
                 retry_limit: 2
                 retry_delay: 500
@@ -68,30 +68,10 @@ spec: &spec
                     cache-control: no-cache
 
               summary_rerender_transcludes:
+                <<: *summary_rerender_spec
                 topic: change-prop.transcludes.resource-change
-                retry_limit: 2
-                retry_delay: 500
-                retry_on:
-                  status:
-                    - '5xx'
-                match:
-                  meta:
-                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
-                  tags:
-                    - restbase
-                match_not:
-                  meta:
-                    domain: '/wiktionary.org$/'
-                exec:
-                  method: get
-                  # Don't encode title since it should be already encoded
-                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
-                  query:
-                    redirect: false
-                  headers:
-                    cache-control: no-cache
 
-              definition_rerender:
+              definition_rerender: &definition_rerender_spec
                 topic: resource_change
                 retry_limit: 2
                 retry_delay: 500
@@ -116,30 +96,10 @@ spec: &spec
                     cache-control: no-cache
 
               definition_rerender_transcludes:
+                <<: *definition_rerender_spec
                 topic: change-prop.transcludes.resource-change
-                retry_limit: 2
-                retry_delay: 500
-                retry_on:
-                  status:
-                    - '5xx'
-                match:
-                  meta:
-                    # These URIs are coming from RESTBase, so we know that article titles will be normalized
-                    # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
-                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A|\/).)+)$/'
-                    domain: '/^en.wiktionary.org$/'
-                  tags:
-                    - restbase
-                exec:
-                  method: get
-                  # Don't encode title since it should be already encoded
-                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/definition/{{match.meta.uri.title}}'
-                  query:
-                    redirect: false
-                  headers:
-                    cache-control: no-cache
 
-              mobile_rerender:
+              mobile_rerender: &mobile_rerender_spec
                 topic: resource_change
                 retry_limit: 2
                 retry_delay: 500
@@ -160,24 +120,8 @@ spec: &spec
                     cache-control: no-cache
 
               mobile_rerender_transcludes:
+                <<: *mobile_rerender_spec
                 topic: change-prop.transcludes.resource-change
-                retry_limit: 2
-                retry_delay: 500
-                retry_on:
-                  status:
-                    - '5xx'
-                match:
-                  meta:
-                    uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
-                  tags:
-                    - restbase
-                exec:
-                  method: get
-                  uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
-                  query:
-                    redirect: false
-                  headers:
-                    cache-control: no-cache
 
               purge_varnish:
                 topic: resource_change


### PR DESCRIPTION
We could potentially do something programmatically to avoid config copy-pasta, but I think it doesn't worth it, being explicit is cleaner in this case.

Bug: https://phabricator.wikimedia.org/T145804
cc @wikimedia/services 