### PR TITLE
Give ORES it's own module

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -9,6 +9,33 @@ spec: &spec
               user-agent: true
   title: The Change Propagation root
   paths:
+    /sys/ores:
+      x-modules:
+        - path: sys/ores.js
+          options:
+            uri: https://ores.wikimedia.org
+            models:
+              arwiki: 'reverted'
+              cswiki: 'reverted'
+              enwiki: 'reverted|damaging|goodfaith'
+              enwiktionary: 'reverted'
+              eswiki: 'reverted'
+              etwiki: 'reverted'
+              fawiki: 'reverted|damaging|goodfaith'
+              frwiki: 'reverted'
+              hewiki: 'reverted'
+              huwiki: 'reverted'
+              idwiki: 'reverted'
+              itwiki: 'reverted'
+              nlwiki: 'reverted|damaging|goodfaith'
+              plwiki: 'reverted|damaging|goodfaith'
+              ptwiki: 'reverted|damaging|goodfaith'
+              ruwiki: 'reverted|damaging|goodfaith'
+              trwiki: 'reverted|damaging|goodfaith'
+              ukwiki: 'reverted'
+              viwiki: 'reverted'
+              wikidatawiki: 'reverted|damaging|goodfaith'
+
     /sys/purge:
       x-modules:
         - path: sys/purge.js
@@ -294,226 +321,23 @@ spec: &spec
                     - 503
                 cases:
                   - match:
-                      meta:
-                        domain: ar.wikipedia.org
+                      database: '/^(:?(:?ar|cs|en|es|et|fa|fr|he|hu|id|it|nl|pl|pt|ru|tr|uk|vi|wi)wiki|enwiktionary)$/'
                       performer:
                         user_is_bot: false
                     exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/arwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: cs.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/cswiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: en.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/enwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: en.wiktionary.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/enwiktionary/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: es.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/eswiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: et.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/etwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: fa.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/fawiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: fr.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/frwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: he.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/hewiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: hu.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/huwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: id.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/idwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: it.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/itwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: nl.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: pl.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/plwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: pt.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: ru.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: tr.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/trwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: uk.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/ukwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: vi.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/viwiki/'
-                      query:
-                        models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
+                      method: post
+                      uri: '/sys/ores/'
+                      body: '{{globals.message}}'
+                  - match: # For wikidata only follow main namespace
                       meta:
                         domain: wikidata.org
                       page_namespace: 0
                       performer:
                         user_is_bot: false
                     exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
+                      method: post
+                      uri: '/sys/ores/'
+                      body: '{{globals.message}}'
 
               # This is not yet used in production
               process_redlinks:

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -208,11 +208,7 @@ class BaseExecutor {
             statDelayStartTime || new Date(origEvent.meta.dt));
 
         return P.each(handler.exec, (tpl) => {
-            const request = tpl.expand(expander);
-            request.headers = Object.assign(request.headers, {
-                'x-request-id': origEvent.meta.request_id,
-                'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
-            });
+            const request = utils.augmentRequest(tpl.expand(expander), retryEvent || origEvent);
             return this.hyper.request(request)
             .tap((res) => {
                 if (res.status === 301) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,4 +16,12 @@ utils.triggeredBy = (event) => {
     return prevTrigger + event.meta.topic + ':' + event.meta.uri;
 };
 
+utils.augmentRequest = (request, event) => {
+    request.headers = Object.assign(request.headers || {}, {
+        'x-request-id': event.meta.request_id,
+        'x-triggered-by': utils.triggeredBy(event)
+    });
+    return request;
+};
+
 module.exports = utils;

--- a/sys/ores.js
+++ b/sys/ores.js
@@ -16,7 +16,7 @@ class OresUpdater {
         const rev_id = req.body.rev_id;
         if (!this.options.models[wiki]) {
             throw new HTTPError({
-                status: 200,
+                status: 400,
                 body: {
                     message: `ORES precache request for unmodified wiki ${wiki}`
                 }

--- a/sys/ores.js
+++ b/sys/ores.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const utils = require('../lib/utils');
+const HTTPError = require('hyperswitch').HTTPError;
 
 class OresUpdater {
     constructor(options) {
@@ -14,10 +15,12 @@ class OresUpdater {
         const wiki = req.body.database;
         const rev_id = req.body.rev_id;
         if (!this.options.models[wiki]) {
-            hyper.log('warn/ores', {
-                message: `ORES precache request for unmodified wiki ${wiki}`
+            throw new HTTPError({
+                status: 200,
+                body: {
+                    message: `ORES precache request for unmodified wiki ${wiki}`
+                }
             });
-            return { status: 200 };
         }
 
         return hyper.get(utils.augmentRequest({

--- a/sys/ores.js
+++ b/sys/ores.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const utils = require('../lib/utils');
+
+class OresUpdater {
+    constructor(options) {
+        this.options = options;
+        if (!options.uri) {
+            throw new Error('Invalid options of ORES module, uri required');
+        }
+    }
+
+    updateORES(hyper, req) {
+        const wiki = req.body.database;
+        const rev_id = req.body.rev_id;
+        if (!this.options.models[wiki]) {
+            hyper.log('warn/ores', {
+                message: `ORES precache request for unmodified wiki ${wiki}`
+            });
+            return { status: 200 };
+        }
+
+        return hyper.get(utils.augmentRequest({
+            uri: this.options.uri + '/v2/scores/' + wiki + '/',
+            query: {
+                models: this.options.models[wiki],
+                revids: rev_id,
+                precache: true
+            }
+        }, req.body));
+    }
+}
+
+module.exports = function(options) {
+    const oresUpdater = new OresUpdater(options);
+    return {
+        spec: {
+            paths: {
+                '/': {
+                    post: {
+                        operationId: 'updateORES'
+                    }
+                }
+            }
+        },
+        operations: {
+            updateORES: oresUpdater.updateORES.bind(oresUpdater)
+        }
+    };
+};

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -409,7 +409,8 @@ describe('RESTBase update rules', function() {
                 rev_parent_id: 1233,
                 performer: {
                     user_is_bot: false
-                }
+                },
+                database: 'enwiki'
             })
         })
         .then(() => common.checkAPIDone(oresService))


### PR DESCRIPTION
There are talks about adding a topic with 'bad edits' Do do this we need to
1. Update ORES
2. If ORES rates are bad - construct and emit a new event to the bad edits topic.

It's not quite possible to do this purely in the config - we need conditional, complex request-handler support etc. I don't think it worths adding all those capabilities, so give ORES it's own JS module.

cc @wikimedia/services 
