### PR TITLE
Go back to blizzard driver since bugs that blocked us weer resolved

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -3,7 +3,7 @@
 const P = require('bluebird');
 const uuid = require('cassandra-uuid').TimeUuid;
 const HTTPError = require('hyperswitch').HTTPError;
-const kafka = require('wikimedia-node-rdkafka');
+const kafka = require('node-rdkafka');
 
 const utils = require('./utils');
 

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const kafka = require('wikimedia-node-rdkafka');
+const kafka = require('node-rdkafka');
 const P = require('bluebird');
 
 const CONSUMER_DEFAULTS = {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "json-stable-stringify": "^1.0.1",
     "htcp-purge": "^0.1.2",
     "mediawiki-title": "^0.5.5",
-    "wikimedia-node-rdkafka": "^0.3.1"
+    "node-rdkafka": "^0.5.1"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",


### PR DESCRIPTION
We've used our own fork because of this bug: https://github.com/Blizzard/node-rdkafka/issues/19

The `rebalance_cb` is not set in upstream by default any more, so we can safely switch back to upstream version. I've tested it for a while and verified it's all right.

cc @wikimedia/services 