### PR TITLE
Update summary when pageimage property is changed

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -578,7 +578,7 @@ spec: &spec
                   meta:
                     uri: '/^https?:\/\/[^\/]+\/wiki\/(?<title>.+)$/'
                   tags:
-                    - pageimages
+                    - page_image
                 exec:
                   method: get
                   uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -570,6 +570,22 @@ spec: &spec
                     query:
                       redirect: false
 
+              # Rerender summary when pageimages page property change
+              # This is a temporary workaround until we get a complete page properties change event.
+              page_images:
+                topic: resource_change
+                match:
+                  meta:
+                    uri: '/^https?:\/\/[^\/]+\/wiki\/(?<title>.+)$/'
+                  tags:
+                    - pageimages
+                exec:
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
+                  query:
+                    redirect: false
 
 num_workers: 0
 logging:

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -55,6 +55,38 @@ describe('RESTBase update rules', function() {
         .finally(() => nock.cleanAll());
     });
 
+    it('Should update summary endpoint on page images change', () => {
+        const mwAPI = nock('https://en.wikipedia.org', {
+            reqheaders: {
+                'cache-control': 'no-cache',
+                'x-triggered-by': 'resource_change:https://en.wikipedia.org/wiki/Some_Page',
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance'
+            }
+        })
+        .get('/api/rest_v1/page/summary/Some_Page')
+        .query({ redirect: false })
+        .reply(200, { });
+
+        return producer.produceAsync({
+            topic: 'test_dc.resource_change',
+            message: JSON.stringify({
+                meta: {
+                    topic: 'resource_change',
+                    schema_uri: 'resource_change/1',
+                    uri: 'https://en.wikipedia.org/wiki/Some_Page',
+                    request_id: common.SAMPLE_REQUEST_ID,
+                    id: uuid.now(),
+                    dt: new Date().toISOString(),
+                    domain: 'en.wikipedia.org'
+                },
+                tags: [ 'pageimages' ]
+            })
+        })
+        .then(() => common.checkAPIDone(mwAPI))
+        .finally(() => nock.cleanAll());
+    });
+
     it('Should update definition endpoint', () => {
         const mwAPI = nock('https://en.wiktionary.org', {
             reqheaders: {

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -80,7 +80,7 @@ describe('RESTBase update rules', function() {
                     dt: new Date().toISOString(),
                     domain: 'en.wikipedia.org'
                 },
-                tags: [ 'pageimages' ]
+                tags: [ 'page_image' ]
             })
         })
         .then(() => common.checkAPIDone(mwAPI))


### PR DESCRIPTION
Simple rule to rerender summary once pageimage properties is changed. Note that this PR needs to be accompanied by the relevant EventBus extension change in order to take effect.

Bug: [T145569](https://phabricator.wikimedia.org/T145569)