### PR TITLE
Add libsasl2-dev to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
           "packages": [
             "librdkafka-dev"
           ]
-        }
+        },
+        "libsasl2-dev"
       ]
     }
   }


### PR DESCRIPTION
Now that we have switched back to the Blizzard driver, we need the `libsasl2` development library headers in order to be able to build the driver in Docker.