### PR TITLE
Check that value we are testing with a regex is actually a string

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -592,25 +592,21 @@ spec: &spec
                 # We don't support 'OR' in the match section, so workaround it by 2 cases with identical exec
                 cases:
                   - match:
-                      meta:
-                        uri: '/^https?:\/\/[^\/]+\/wiki\/(?<title>.+)$/'
                       added_properties:
                         page_image: '/.+/' # Regex that matches anything just to check the prop is set
                     exec:
                       method: get
-                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
+                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{message.page_title}'
                       headers:
                         cache-control: no-cache
                       query:
                         redirect: false
                   - match:
-                      meta:
-                        uri: '/^https?:\/\/[^\/]+\/wiki\/(?<title>.+)$/'
                       removed_properties:
                         page_image: '/.+/' # Regex that matches anything just to check the prop is set
                     exec:
                       method: get
-                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
+                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{message.page_title}'
                       headers:
                         cache-control: no-cache
                       query:

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -80,7 +80,7 @@ function _compileNamedRegex(obj, result, name, fieldName) {
         result[fieldName] = `${code}return res; })()`;
     }
 
-    return `${normalRegex}.test(${name})`;
+    return `typeof ${name} === "string" && ${normalRegex}.test(${name})`;
 }
 
 function _compileMatch(obj, result, name, fieldName) {

--- a/test/feature/rule.js
+++ b/test/feature/rule.js
@@ -83,6 +83,17 @@ describe('Rule', function() {
             assert.equal(r.test(msg), 0, 'Expected the rule to match the given message!');
         });
 
+        it('regex match with undefined', function() {
+            var r = new Rule('rule', {
+                topic: 'nono',
+                exec: {uri: 'a/b/c'},
+                match: {number: 1, string: '/.+/'}
+            });
+            var msgWithUndefined = Object.assign({}, msg);
+            msgWithUndefined.string = undefined;
+            assert.equal(r.test(msgWithUndefined), -1, 'Expected the rule not to match the given message!');
+        });
+
         it('regex mismatch', function() {
             var r = new Rule('rule', {
                 topic: 'nono',

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -82,7 +82,8 @@ describe('RESTBase update rules', function() {
                 },
                 added_properties: {
                     page_image: 'Test.jpg'
-                }
+                },
+                page_title: 'Some_Page'
             })
         })
         .then(() => common.checkAPIDone(mwAPI))


### PR DESCRIPTION
JavaScript keeps surprising, `/.+/.test(undefined) === true`.  So we need to check that the value we're testing with a regex is actually a string.

cc @wikimedia/services 