### PR TITLE
Narrow down wikidata description updates

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -539,8 +539,22 @@ spec: &spec
                   headers:
                     cache-control: no-cache
 
-              wikidata_description:
+              wikidata_description_on_edit:
                 topic: mediawiki.revision-create
+                match:
+                  meta:
+                    domain: www.wikidata.org
+                  page_namespace: 0
+                  # It's impossible to modify a comment in wikidata while editing the entity.
+                  # TODO: This is a temp solution until we get a more general fragment support T148079
+                  comment: '/wbeditentity/'
+                exec:
+                  method: 'post'
+                  uri: '/sys/links/wikidata_descriptions'
+                  body: '{{globals.message}}'
+
+              wikidata_description_on_revision_visibility_change:
+                topic: mediawiki.revision-visibility-change
                 match:
                   meta:
                     domain: www.wikidata.org

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -506,7 +506,73 @@ describe('RESTBase update rules', function() {
                     domain: 'www.wikidata.org'
                 },
                 page_title: 'Q1',
-                page_namespace: 0
+                page_namespace: 0,
+                comment: "/* wbeditentity-update:0| */ add [it] label"
+            })
+        })
+        .delay(common.REQUEST_CHECK_DELAY)
+        .then(() => common.checkAPIDone(wikidataAPI))
+        .then(() => common.checkAPIDone(restbase))
+        .finally(() => nock.cleanAll());
+    });
+
+    it('Should update RESTBase summary and mobile-sections on wikidata revision visibility change', () => {
+        const wikidataAPI = nock('https://www.wikidata.org')
+        .post('/w/api.php', {
+            format: 'json',
+            formatversion: '2',
+            action: 'wbgetentities',
+            ids: 'Q2',
+            props: 'sitelinks/urls',
+            normalize: 'true'
+        })
+        .reply(200, {
+            "success": 1,
+            "entities": {
+                "Q2": {
+                    "type": "item",
+                    "id": "Q2",
+                    "sitelinks": {
+                        "enwiki": {
+                            "site": "ruwiki",
+                            "title": "Пётр",
+                            "badges": [],
+                            "url": "https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80"
+                        }
+                    }
+                }
+            }
+        });
+
+        const restbase = nock('https://ru.wikipedia.org', {
+            reqheaders: {
+                'cache-control': 'no-cache',
+                'x-request-id': common.SAMPLE_REQUEST_ID,
+                'user-agent': 'SampleChangePropInstance',
+                'x-triggered-by': 'mediawiki.revision-visibility-change:/rev/uri,change-prop.transcludes.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80'
+            }
+        })
+        .get('/api/rest_v1/page/summary/%D0%9F%D1%91%D1%82%D1%80')
+        .query({ redirect: false })
+        .reply(200, { })
+        .get('/api/rest_v1/page/mobile-sections/%D0%9F%D1%91%D1%82%D1%80')
+        .query({ redirect: false })
+        .reply(200, { });
+
+        return producer.produceAsync({
+            topic: 'test_dc.mediawiki.revision-visibility-change',
+            message: JSON.stringify({
+                meta: {
+                    topic: 'mediawiki.revision-visibility-change',
+                    schema_uri: 'revision-visibility-change/1',
+                    uri: '/rev/uri',
+                    request_id: common.SAMPLE_REQUEST_ID,
+                    id: uuid.now(),
+                    dt: new Date().toISOString(),
+                    domain: 'www.wikidata.org'
+                },
+                page_title: 'Q2',
+                page_namespace: 0,
             })
         })
         .delay(common.REQUEST_CHECK_DELAY)
@@ -593,7 +659,8 @@ describe('RESTBase update rules', function() {
                     domain: 'www.wikidata.org'
                 },
                 page_title: 'Q2',
-                page_namespace: 0
+                page_namespace: 0,
+                comment: "/* wbeditentity-update:0| */ add [it] label"
             })
         })
         .delay(common.REQUEST_CHECK_DELAY)


### PR DESCRIPTION
Almost 2/3 of the load on MCS cluster is due to wikidata-description updates. Before, to be on the safe side, we've been rerendering all summaries/mobile content whenever a wikidata item's changed. But actual description changes are like 1% of them, so we doing lots of extra work. 

Good news is there's a way to rule out most of the unnesessary updates by looking at the edit comment - it's impossible to modify that comment when edit is made, so they're pretty stable.
It's a hack solution, because those comments are not a part of the official wikidata API or contract, so I'm proposing better, more general solutions in the ticket, but that might take time, and we need to lower the load right now without waiting for that.

Another thing is that if a wikidata item revision is suppressed, we might need to rerender summary/mobile as well, because it's quite likely that some description was vandalised and the revision suppression is a result of that vandalism. The rate of revision suppressions is super low, so we can avoid doing any more fine-grained filtering here.

Bug: https://phabricator.wikimedia.org/T148079