### PR TITLE
Added description to the commit error

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -151,7 +151,7 @@ class BaseExecutor {
                             msg: 'Commit failed',
                             offset: committing.offset,
                             event: committing.message.toString(),
-                            error: e
+                            description: e.toString()
                         });
                     });
                 }


### PR DESCRIPTION
The `Error` object created by `node-rdkafka` is not being rendered correctly by logger, so call `toString` to add description explicitly.

Bug: https://phabricator.wikimedia.org/T148820