### PR TITLE
Improved logging levels

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -275,7 +275,7 @@ class BaseExecutor {
      */
     _isLimitExceeded(message, e) {
         if (message.retries_left <= 0) {
-            this.log(`error/${this.rule.name}`, {
+            this.log(`warn/${this.rule.name}`, {
                 message: 'Retry count exceeded',
                 event: message,
                 error: e

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -344,6 +344,9 @@ class DependencyProcessor {
                 message
             }))
             .then((res) => {
+                if (!res || !res.body || !res.body.query || !res.body.query.general) {
+                    throw new Error(`SiteInfo is unavailable for ${message.meta.domain}`);
+                }
                 return {
                     general: {
                         lang: res.body.query.general.lang,


### PR DESCRIPTION
Our logs for change-prop are full of `retry count exceeded` messages, which are quite useless. If we wanna see the events for which the retry count was exceeded, we can go to kafka error topic.

cc @wikimedia/services 