### PR TITLE
Ignore updates from all Wikidata domains

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -60,7 +60,7 @@ spec: &spec
                       - meta:
                           domain: '/wiktionary.org$/'
                       - meta:
-                          domain: www.wikidata.org
+                          domain: /\.wikidata\.org$/
                     exec:
                       method: get
                       # Don't encode title since it should be already encoded
@@ -104,7 +104,7 @@ spec: &spec
                     - restbase
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: get
                   uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
@@ -126,7 +126,7 @@ spec: &spec
                     - restbase
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: post
                   uri: '/sys/purge/'
@@ -148,7 +148,7 @@ spec: &spec
                     - purge
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: get
                   uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
@@ -171,7 +171,7 @@ spec: &spec
                     - null_edit
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: get
                   uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
@@ -189,7 +189,7 @@ spec: &spec
                     - 404 # Sometimes occasional 404s happen because of the mysql replication lag, so retry
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: get
                   uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'
@@ -208,7 +208,7 @@ spec: &spec
                     - 412
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: get
                   uri: 'https://{{message.meta.domain}}/api/rest_v1/page/revision/{{message.rev_id}}'
@@ -225,7 +225,7 @@ spec: &spec
                     - 412
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   - method: get
                     uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.page_title}'
@@ -258,7 +258,7 @@ spec: &spec
                 topic: mediawiki.page-undelete
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: get
                   uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}'
@@ -271,7 +271,7 @@ spec: &spec
                 topic: mediawiki.page-move
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   - method: get
                     uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'
@@ -294,7 +294,7 @@ spec: &spec
                 match_not:
                   - rev_parent_id: undefined
                   - meta:
-                      domain: www.wikidata.org
+                      domain: /\.wikidata\.org$/
                 # end of test-only config
                 exec:
                   method: post
@@ -555,7 +555,7 @@ spec: &spec
                   rev_parent_id: undefined
                 match_not:
                   meta:
-                    domain: www.wikidata.org
+                    domain: /\.wikidata\.org$/
                 exec:
                   method: post
                   uri: '/sys/links/backlinks/{message.page_title}'
@@ -626,7 +626,7 @@ spec: &spec
                         page_image: '/.+/' # Regex that matches anything just to check the prop is set
                     match_not:
                       meta:
-                        domain: www.wikidata.org
+                        domain: /\.wikidata\.org$/
                     exec:
                       - method: get
                         uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{message.page_title}'
@@ -645,7 +645,7 @@ spec: &spec
                         page_image: '/.+/' # Regex that matches anything just to check the prop is set
                     match_not:
                       meta:
-                        domain: www.wikidata.org
+                        domain: /\.wikidata\.org$/
                     exec:
                       - method: get
                         uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{message.page_title}'


### PR DESCRIPTION
In production there are www.wikidata.org and test.wikidata.org. We want
to ignore both of them when it comes to updates.

Bug: [T149114](https://phabricator.wikimedia.org/T149114)