### PR TITLE
Change the endpoint we call for page restore

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -261,7 +261,7 @@ spec: &spec
                     domain: /\.wikidata\.org$/
                 exec:
                   method: get
-                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}'
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/title/{message.page_title}'
                   headers:
                     cache-control: no-cache
                   query:

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -351,7 +351,7 @@ describe('RESTBase update rules', function() {
                 'user-agent': 'SampleChangePropInstance'
             }
         })
-        .get('/api/rest_v1/page/html/User%3APchelolo%2FTest')
+        .get('/api/rest_v1/page/title/User%3APchelolo%2FTest')
         .query({ redirect: false })
         .reply(200, { });
 


### PR DESCRIPTION
After we switch to restriction-table based access checking we'd need to call a different endpoint to signal an undelete. The revision-table based wouldn't be broken too, so it's safe to deploy prior to the switch.

The problem is that on the HTML endpoint the access check is done in parallel with content request, and the content request is the one that would update the restriction table, so we get a race condition. Notifying the `title` endpoint avoids that issue.

cc @wikimedia/services 