### PR TITLE
Made logging more consistent

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -150,7 +150,7 @@ class BaseExecutor {
                         this.log(`error/commit/${this.rule.name}`, {
                             msg: 'Commit failed',
                             offset: committing.offset,
-                            raw_event: JSON.stringify(committing.message),
+                            raw_event: utils.stringify(committing.message),
                             description: e.toString()
                         });
                     });
@@ -169,7 +169,7 @@ class BaseExecutor {
                 // no match, drop the message
                 this.log(`debug/${this.rule.name}`, {
                     msg: 'Dropping event message',
-                    event: JSON.stringify(event)
+                    event: utils.stringify(event)
                 });
             }
             return optionIndex;
@@ -182,7 +182,7 @@ class BaseExecutor {
     _sampleLog(event, request, res) {
         const sampleLog = {
             message: 'Processed event sample',
-            event: JSON.stringify(event),
+            event: utils.stringify(event),
             request,
             response: {
                 status: res.status,
@@ -206,7 +206,7 @@ class BaseExecutor {
 
         this.log(`trace/${rule.name}`, {
             msg: 'Event message received',
-            event: JSON.stringify(origEvent) });
+            event: utils.stringify(origEvent) });
 
         // latency from the original event creation time to execution time
         this.hyper.metrics.endTiming([`${this.statName}_delay`],
@@ -226,7 +226,7 @@ class BaseExecutor {
                     this.log(`warn/${this.rule.name}`, {
                         message: '301 redirect received, used a non-normalized title',
                         rule: this.rule.name,
-                        event: JSON.stringify(origEvent)
+                        event: utils.stringify(origEvent)
                     });
                 }
             })
@@ -280,7 +280,7 @@ class BaseExecutor {
         if (message.retries_left <= 0) {
             this.log(`info/${this.rule.name}`, {
                 message: 'Retry count exceeded',
-                event: JSON.stringify(message),
+                event: utils.stringify(message),
                 description: `${e}`
             });
             return true;
@@ -301,7 +301,7 @@ class BaseExecutor {
                 message: 'Internal error in change-prop',
                 description: `${e}`,
                 stack: e.stack,
-                event: JSON.stringify(message)
+                event: utils.stringify(message)
             });
             return reportError();
         }

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -150,7 +150,7 @@ class BaseExecutor {
                         this.log(`error/commit/${this.rule.name}`, {
                             msg: 'Commit failed',
                             offset: committing.offset,
-                            event: committing.message.toString(),
+                            raw_event: JSON.stringify(committing.message),
                             description: e.toString()
                         });
                     });
@@ -168,7 +168,8 @@ class BaseExecutor {
             if (optionIndex === -1) {
                 // no match, drop the message
                 this.log(`debug/${this.rule.name}`, {
-                    msg: 'Dropping event message', event
+                    msg: 'Dropping event message',
+                    event: JSON.stringify(event)
                 });
             }
             return optionIndex;
@@ -181,7 +182,7 @@ class BaseExecutor {
     _sampleLog(event, request, res) {
         const sampleLog = {
             message: 'Processed event sample',
-            event,
+            event: JSON.stringify(event),
             request,
             response: {
                 status: res.status,
@@ -203,7 +204,9 @@ class BaseExecutor {
             match: handler.expand(origEvent)
         };
 
-        this.log(`trace/${rule.name}`, { msg: 'Event message received', event: origEvent });
+        this.log(`trace/${rule.name}`, {
+            msg: 'Event message received',
+            event: JSON.stringify(origEvent) });
 
         // latency from the original event creation time to execution time
         this.hyper.metrics.endTiming([`${this.statName}_delay`],
@@ -223,7 +226,7 @@ class BaseExecutor {
                     this.log(`warn/${this.rule.name}`, {
                         message: '301 redirect received, used a non-normalized title',
                         rule: this.rule.name,
-                        event: origEvent
+                        event: JSON.stringify(origEvent)
                     });
                 }
             })
@@ -275,10 +278,10 @@ class BaseExecutor {
      */
     _isLimitExceeded(message, e) {
         if (message.retries_left <= 0) {
-            this.log(`warn/${this.rule.name}`, {
+            this.log(`info/${this.rule.name}`, {
                 message: 'Retry count exceeded',
-                event: message,
-                error: e
+                event: JSON.stringify(message),
+                description: `${e}`
             });
             return true;
         }
@@ -296,9 +299,9 @@ class BaseExecutor {
             // some bug in change-prop. Log and send a fatal error message.
             this.hyper.log(`error/${this.rule.name}`, {
                 message: 'Internal error in change-prop',
-                error: `${e}`,
+                description: `${e}`,
                 stack: e.stack,
-                event: message
+                event: JSON.stringify(message)
             });
             return reportError();
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,4 +16,18 @@ utils.triggeredBy = (event) => {
     return `${prevTrigger + event.meta.topic}:${event.meta.uri}`;
 };
 
+/**
+ * Safely stringifies the event to JSON string.
+ *
+ * @param {Object} event the event to stringify
+ * @return {string|undefined} stringified event or undefined if failed.
+ */
+utils.stringify = (event) => {
+    try {
+        return JSON.stringify(event);
+    } catch (e) {
+        return undefined;
+    }
+};
+
 module.exports = utils;

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -259,7 +259,7 @@ class DependencyProcessor {
             if (res.body && res.body.error) {
                 this.log('warn/wikidata_description', {
                     msg: 'Could not extract items',
-                    event: JSON.stringify(context.message),
+                    event: utils.stringify(context.message),
                     error: res.body.error
                 });
             }

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -259,7 +259,7 @@ class DependencyProcessor {
             if (res.body && res.body.error) {
                 this.log('warn/wikidata_description', {
                     msg: 'Could not extract items',
-                    event: context.message,
+                    event: JSON.stringify(context.message),
                     error: res.body.error
                 });
             }

--- a/sys/purge.js
+++ b/sys/purge.js
@@ -37,7 +37,7 @@ class PurgeService {
             if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri)) {
                 hyper.log('error/events/purge', {
                     message: 'Invalid event URI',
-                    event
+                    event: JSON.stringify(event)
                 });
                 return undefined;
             }

--- a/sys/purge.js
+++ b/sys/purge.js
@@ -4,6 +4,7 @@ const Purger      = require('htcp-purge');
 const HyperSwitch = require('hyperswitch');
 const HTTPError   = HyperSwitch.HTTPError;
 const lifecicle   = HyperSwitch.lifecycle;
+const utils       = require('../lib/utils');
 
 class PurgeService {
     constructor(options) {
@@ -37,7 +38,7 @@ class PurgeService {
             if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri)) {
                 hyper.log('error/events/purge', {
                     message: 'Invalid event URI',
-                    event: JSON.stringify(event)
+                    event: utils.stringify(event)
                 });
                 return undefined;
             }


### PR DESCRIPTION
We need to emit consistent types of properties at least within the service. Also, it doesn't make sense to emit the original even as object, we never index it anyway. Stringified version is OK.

Bug: https://phabricator.wikimedia.org/T150195