### PR TITLE
Use delivery callback to guarantee delivery

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -27,13 +27,22 @@ class GuaranteedProducer extends kafka.Producer {
     /**
      * @inheritDoc
      */
-    constructor(conf, topicConf) {
+    constructor(conf, topicConf, logger) {
         super(conf, topicConf);
+        this._logger = logger;
         this._pending = {};
 
         this.on('delivery-report', (report) => {
             const reportKey = `${report.topic}:${report.key}`;
             const resolve = this._pending[reportKey];
+            if (!resolve) {
+                this._logger.log('error/produce', {
+                    message: 'Unknown resolver in delivery report',
+                    report
+                });
+                return;
+            }
+            
             delete this._pending[reportKey];
             resolve(report);
         });
@@ -164,11 +173,13 @@ class KafkaFactory {
         });
     }
 
-    _createProducerOfClass(ProducerClass) {
+    _createProducerOfClass(ProducerClass, logger) {
         return new P((resolve, reject) => {
             const producer = new ProducerClass(
                 this._producerConf,
-                this._producerTopicConf);
+                this._producerTopicConf,
+                logger
+            );
             producer.once('error', reject);
             producer.connect(undefined, (err) => {
                 if (err) {
@@ -180,12 +191,12 @@ class KafkaFactory {
 
     }
 
-    createProducer() {
-        return this._createProducerOfClass(kafka.Producer);
+    createProducer(logger) {
+        return this._createProducerOfClass(kafka.Producer, logger);
     }
 
-    createGuaranteedProducer() {
-        return this._createProducerOfClass(GuaranteedProducer);
+    createGuaranteedProducer(logger) {
+        return this._createProducerOfClass(GuaranteedProducer, logger);
     }
 }
 module.exports = KafkaFactory;

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -42,7 +42,7 @@ class GuaranteedProducer extends kafka.Producer {
                 });
                 return;
             }
-            
+
             delete this._pending[reportKey];
             resolve(report);
         });
@@ -178,7 +178,7 @@ class KafkaFactory {
             const producer = new ProducerClass(
                 this._producerConf,
                 this._producerTopicConf,
-                logger
+                logger || function() {}
             );
             producer.once('error', reject);
             producer.connect(undefined, (err) => {

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -170,8 +170,12 @@ class KafkaFactory {
                 this._producerConf,
                 this._producerTopicConf);
             producer.once('error', reject);
-            producer.once('ready', () => resolve(producer));
-            producer.connect();
+            producer.connect(undefined, (err) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve(producer);
+            });
         });
 
     }

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -178,7 +178,7 @@ class KafkaFactory {
             const producer = new ProducerClass(
                 this._producerConf,
                 this._producerTopicConf,
-                logger || function() {}
+                logger || (() => {})
             );
             producer.once('error', reject);
             producer.connect(undefined, (err) => {

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -20,8 +20,73 @@ const PRODUCER_DEFAULTS = {
 };
 
 const PRODUCER_TOPIC_DEFAULTS = {
-
+    'request.required.acks': 1
 };
+
+class GuaranteedProducer extends kafka.Producer {
+    /**
+     * @inheritDoc
+     */
+    constructor(conf, topicConf) {
+        super(conf, topicConf);
+        this._pending = {};
+
+        this.on('delivery-report', (report) => {
+            const reportKey = `${report.topic}:${report.key}`;
+            const resolve = this._pending[reportKey];
+            delete this._pending[reportKey];
+            resolve(report);
+        });
+
+        this._pollInterval = setInterval(() => this.poll(), 500);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    produce(topic, partition, message, key) {
+        return new P((resolve, reject) => {
+            if (!key) {
+                process.nextTick(() =>
+                    reject(new Error('Key is required for guaranteed delivery')));
+                return;
+            }
+
+            const reportKey = `${topic}:${key}`;
+
+            if (this._pending[reportKey]) {
+                process.nextTick(() => reject(new Error(`Duplicate key: ${reportKey}`)));
+                return;
+            }
+
+            this._pending[reportKey] = resolve;
+
+            try {
+                const result = super.produce(topic, partition, message, key);
+                if (result !== true) {
+                    process.nextTick(() => {
+                        delete this._pending[reportKey];
+                        reject(result);
+                    });
+                }
+            } catch (e) {
+                process.nextTick(() => {
+                    delete this._pending[reportKey];
+                    reject(e);
+                });
+            }
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    disconnect(cb) {
+        clearInterval(this._pollInterval);
+        return super.disconnect(cb);
+    }
+
+}
 
 class KafkaFactory {
     /**
@@ -99,15 +164,24 @@ class KafkaFactory {
         });
     }
 
-    createProducer() {
+    _createProducerOfClass(ProducerClass) {
         return new P((resolve, reject) => {
-            const producer = new kafka.Producer(
+            const producer = new ProducerClass(
                 this._producerConf,
                 this._producerTopicConf);
             producer.once('error', reject);
             producer.once('ready', () => resolve(producer));
             producer.connect();
         });
+
+    }
+
+    createProducer() {
+        return this._createProducerOfClass(kafka.Producer);
+    }
+
+    createGuaranteedProducer() {
+        return this._createProducerOfClass(GuaranteedProducer);
     }
 }
 module.exports = KafkaFactory;

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -26,7 +26,7 @@ class Kafka {
     }
 
     setup(hyper) {
-        return this.kafkaFactory.createGuaranteedProducer()
+        return this.kafkaFactory.createGuaranteedProducer(this.log)
         .then((producer) => {
             this.producer = producer;
             HyperSwitch.lifecycle.on('close', () => this.producer.disconnect());


### PR DESCRIPTION
After we've updated to `node-rdkafka@0.6.0` we finally can use the delivery report to track message production up to kafka broker. Now production becomes guaranteed for real, not just until entering the librdkafka internal production buffer.

cc @wikimedia/services 