### PR TITLE
Specify a key location for the apt.wikimedia.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
       "debian": [
         {
           "repo_url": "https://apt.wikimedia.org/wikimedia",
+          "key_url": "https://wikitech.wikimedia.org/w/index.php?title=APT_repository/Key&action=raw",
           "release": "jessie-wikimedia",
           "pool": "main",
           "packages": [


### PR DESCRIPTION
Depends on https://github.com/wikimedia/service-runner/pull/142
cc @wikimedia/services 