### PR TITLE
Rerender summary and mobile when wikidata item is undeleted

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -606,8 +606,8 @@ spec: &spec
                   uri: '/sys/links/wikidata_descriptions'
                   body: '{{globals.message}}'
 
-              wikidata_description_on_edit:
-                topic: mediawiki.page-delete
+              wikidata_description_on_undelete:
+                topic: mediawiki.page-undelete
                 match:
                   meta:
                     domain: www.wikidata.org

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -606,6 +606,17 @@ spec: &spec
                   uri: '/sys/links/wikidata_descriptions'
                   body: '{{globals.message}}'
 
+              wikidata_description_on_edit:
+                topic: mediawiki.page-delete
+                match:
+                  meta:
+                    domain: www.wikidata.org
+                  page_namespace: 0
+                exec:
+                  method: post
+                  uri: '/sys/links/wikidata_descriptions'
+                  body: '{{globals.message}}'
+
               wikidata_description_on_revision_visibility_change:
                 topic: mediawiki.revision-visibility-change
                 match:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -617,17 +617,6 @@ spec: &spec
                   uri: '/sys/links/wikidata_descriptions'
                   body: '{{globals.message}}'
 
-              wikidata_description_on_revision_visibility_change:
-                topic: mediawiki.revision-visibility-change
-                match:
-                  meta:
-                    domain: www.wikidata.org
-                  page_namespace: 0
-                exec:
-                  method: post
-                  uri: '/sys/links/wikidata_descriptions'
-                  body: '{{globals.message}}'
-
               on_wikidata_description_change:
                 topic: change-prop.transcludes.resource-change
                 match:

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -518,7 +518,7 @@ describe('RESTBase update rules', function() {
         .finally(() => nock.cleanAll());
     });
 
-    it('Should update RESTBase summary and mobile-sections on wikidata revision visibility change', () => {
+    it('Should update RESTBase summary and mobile-sections on wikidata undelete', () => {
         const wikidataAPI = nock('https://www.wikidata.org')
         .post('/w/api.php', {
             format: 'json',
@@ -551,7 +551,7 @@ describe('RESTBase update rules', function() {
                 'cache-control': 'no-cache',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
                 'user-agent': 'SampleChangePropInstance',
-                'x-triggered-by': 'mediawiki.revision-visibility-change:/rev/uri,change-prop.transcludes.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80'
+                'x-triggered-by': 'mediawiki.page-undelete:/rev/uri,change-prop.transcludes.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80'
             }
         })
         .get('/api/rest_v1/page/summary/%D0%9F%D1%91%D1%82%D1%80')
@@ -561,11 +561,11 @@ describe('RESTBase update rules', function() {
         .query({ redirect: false })
         .reply(200, { });
 
-        return P.try(() => producer.produce('test_dc.mediawiki.revision-visibility-change', 0,
+        return P.try(() => producer.produce('test_dc.mediawiki.page-undelete', 0,
             Buffer.from(JSON.stringify({
                 meta: {
-                    topic: 'mediawiki.revision-visibility-change',
-                    schema_uri: 'revision-visibility-change/1',
+                    topic: 'mediawiki.page-undelete',
+                    schema_uri: 'page-undelet/1',
                     uri: '/rev/uri',
                     request_id: common.SAMPLE_REQUEST_ID,
                     id: uuid.now(),


### PR DESCRIPTION
Need to rerender summary/mobile when wikidata item is undeleted to pull in the descriptions. Unfortunately, we can't do the same for deleted pages since CP doesn't have access to them after it was deleted and so we can't find the list of articles to purge.

Also, summary and mobile depend on the latest revision of the wikidata item and the latest one can't be restricted. So we don't need to rerender on revision-visibility-set event.

cc @wikimedia/services 