### PR TITLE
Interleave continuation with leaf job processing

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -318,19 +318,28 @@ spec: &spec
 
               on_transclusion_update:
                 topic: change-prop.transcludes.resource-change
-                match:
-                  meta:
-                    uri: '/https?:\/\/[^\/]+\/wiki\/(?<title>.+)/'
-                  tags: [ 'transcludes' ]
-                exec:
-                  method: get
-                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-                  headers:
-                    cache-control: no-cache
-                    if-unmodified-since: '{{date(message.meta.dt)}}'
-                    x-restbase-mode: '{{message.tags[1]}}'
-                  query:
-                    redirect: false
+                cases:
+                  - match:
+                      meta:
+                        schema_uri: 'resource_change/1'
+                        uri: '/https?:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+                      tags: [ 'transcludes' ]
+                    exec:
+                      method: get
+                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                      headers:
+                        cache-control: no-cache
+                        if-unmodified-since: '{{date(message.meta.dt)}}'
+                        x-restbase-mode: '{{message.tags[1]}}'
+                      query:
+                        redirect: false
+                  - match:
+                      meta:
+                        schema_uri: 'continue/1'
+                    exec:
+                      method: post
+                      uri: '/sys/links/transcludes/{message.original_event.page_title}'
+                      body: '{{globals.message}}'
 
               # ORES caching updates
               ores_cache:
@@ -581,16 +590,26 @@ spec: &spec
                   body: '{{globals.message}}'
 
               rerender_restbase:
-                topic: change-prop.transcludes.resource-change
-                match:
-                  meta:
-                    uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
-                  tags: [ 'backlinks' ]
-                exec:
-                  method: get
-                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
-                  headers:
-                    cache-control: no-cache
+                topic: change-prop.backlinks.resource-change
+                cases:
+                  - match:
+                      meta:
+                        uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
+                        schema_uri: 'resource_change/1'
+                      tags: [ 'backlinks' ]
+                    exec:
+                      method: get
+                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'
+                      headers:
+                        cache-control: no-cache
+                      refirect: false
+                  - match:
+                      meta:
+                        schema_uri: 'continue/1'
+                    exec:
+                      method: post
+                      uri: '/sys/links/backlinks/{message.original_event.page_title}'
+                      body: '{{globals.message}}'
 
               wikidata_description_on_edit:
                 topic: mediawiki.revision-create

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -875,7 +875,7 @@ describe('RESTBase update rules', function() {
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')
-        .matchHeader('x-triggered-by', 'mediawiki.revision-create:/sample/uri,change-prop.transcludes.resource-change:https://en.wikipedia.org/wiki/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision-create:/sample/uri,change-prop.backlinks.resource-change:https://en.wikipedia.org/wiki/Some_Page')
         .times(2)
         .reply(200)
         .post('/w/api.php', {
@@ -895,7 +895,7 @@ describe('RESTBase update rules', function() {
             }
         })
         .get('/api/rest_v1/page/html/Some_Page')
-        .matchHeader('x-triggered-by', 'mediawiki.revision-create:/sample/uri,change-prop.transcludes.resource-change:https://en.wikipedia.org/wiki/Some_Page')
+        .matchHeader('x-triggered-by', 'mediawiki.revision-create:/sample/uri,change-prop.backlinks.resource-change:https://en.wikipedia.org/wiki/Some_Page')
         .reply(200);
 
         return P.try(() => producer.produce('test_dc.mediawiki.revision-create', 0,

--- a/test/utils/clean_kafka.sh
+++ b/test/utils/clean_kafka.sh
@@ -63,6 +63,8 @@ createTopic "test_dc.mediawiki.revision-visibility-change"
 createTopic "test_dc.change-prop.retry.mediawiki.revision-visibility-change"
 createTopic "test_dc.change-prop.transcludes.resource-change"
 createTopic "test_dc.change-prop.retry.change-prop.transcludes.resource-change"
+createTopic "test_dc.change-prop.backlinks.resource-change"
+createTopic "test_dc.change-prop.retry.change-prop.backlinks.resource-change"
 createTopic "test_dc.mediawiki.page-properties-change"
 createTopic "test_dc.change-prop.retry.mediawiki.page-properties-change"
 wait


### PR DESCRIPTION
Per discussion in https://phabricator.wikimedia.org/T152557 we decided to allow doing whatever in internal CP topics, so it's OK to push 2 different kinds of messages to the transcludes topic.

Needs a config change to be deployed together or before the code.

This is ready for review and deployment. Also tested that the 'transition' mode will work just fine - we will not lose any jobs.

Bug: https://phabricator.wikimedia.org/T152229
cc @wikimedia/services 