### PR TITLE
Move wikidata->mobileapps dependency to it's own resource-change queue

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -637,7 +637,7 @@ spec: &spec
                   body: '{{globals.message}}'
 
               on_wikidata_description_change:
-                topic: change-prop.transcludes.resource-change
+                topic: change-prop.wikidata.resource-change
                 match:
                   meta:
                     uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -90,7 +90,7 @@ function createWikidataTemplate(options) {
             }
         })),
         resourceChangeTags: [ 'wikidata' ],
-        leafTopicName: 'change-prop.transcludes.resource-change',
+        leafTopicName: 'change-prop.wikidata.resource-change',
         shouldProcess: (res) => {
             if (!(res && res.body && !!res.body.success)) {
                 return false;

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -487,7 +487,7 @@ describe('RESTBase update rules', function() {
                 'cache-control': 'no-cache',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
                 'user-agent': 'SampleChangePropInstance',
-                'x-triggered-by': 'mediawiki.revision-create:/rev/uri,change-prop.transcludes.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80'
+                'x-triggered-by': 'mediawiki.revision-create:/rev/uri,change-prop.wikidata.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80'
             }
         })
         .get('/api/rest_v1/page/summary/%D0%9F%D1%91%D1%82%D1%80')
@@ -551,7 +551,7 @@ describe('RESTBase update rules', function() {
                 'cache-control': 'no-cache',
                 'x-request-id': common.SAMPLE_REQUEST_ID,
                 'user-agent': 'SampleChangePropInstance',
-                'x-triggered-by': 'mediawiki.page-undelete:/rev/uri,change-prop.transcludes.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80'
+                'x-triggered-by': 'mediawiki.page-undelete:/rev/uri,change-prop.wikidata.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80'
             }
         })
         .get('/api/rest_v1/page/summary/%D0%9F%D1%91%D1%82%D1%80')

--- a/test/utils/clean_kafka.sh
+++ b/test/utils/clean_kafka.sh
@@ -67,5 +67,8 @@ createTopic "test_dc.change-prop.backlinks.resource-change"
 createTopic "test_dc.change-prop.retry.change-prop.backlinks.resource-change"
 createTopic "test_dc.mediawiki.page-properties-change"
 createTopic "test_dc.change-prop.retry.mediawiki.page-properties-change"
+createTopic "test_dc.change-prop.wikidata.resource-change"
+createTopic "test_dc.change-prop.retry.test_dc.change-prop.wikidata.resource-change"
+
 wait
 sleep 5


### PR DESCRIPTION
Since the android team made the 'edit wikidata item' feature timely updates for mobile endpoints derived from wikidata item change are important, so give it it's own queue.

Bug: https://phabricator.wikimedia.org/T152690