### PR TITLE
Temporarily disable the GuaranteedProducer

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -28,9 +28,10 @@ const PRODUCER_DEFAULTS = {
 };
 
 const PRODUCER_TOPIC_DEFAULTS = {
-    'request.required.acks': 1
+    // 'request.required.acks': 1
 };
 
+/*eslint-disable */
 class GuaranteedProducer extends kafka.Producer {
     /**
      * @inheritDoc
@@ -104,6 +105,7 @@ class GuaranteedProducer extends kafka.Producer {
     }
 
 }
+/*eslint-enable */
 
 class KafkaFactory {
     /**
@@ -228,7 +230,7 @@ class KafkaFactory {
     }
 
     createGuaranteedProducer(logger) {
-        return this._createProducerOfClass(GuaranteedProducer, logger);
+        return this._createProducerOfClass(kafka.Producer, logger);
     }
 }
 module.exports = KafkaFactory;


### PR DESCRIPTION
It feels like deploying the guaranteed producer gave us a memory leak. Temporarily disable it to confirm.

cc @wikimedia/services 