### PR TITLE
Move transclusion updates to the page_edit rule

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -178,22 +178,29 @@ spec: &spec
                   status:
                     - '5xx'
                     - 404 # Sometimes occasional 404s happen because of the mysql replication lag, so retry
+                # Test-only. We use undefined rev_parent_id to test backlinks so we
+                # don't want transclusions to interfere with backlinks test
                 match_not:
+                  - rev_parent_id: undefined
                   - meta:
                       domain: /\.wikidata\.org$/
                     page_namespace: 0
                   - meta:
                       domain: /\.wikidata\.org$/
                     page_namespace: 120
+                # end of test-only config
                 exec:
-                  method: get
-                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'
-                  headers:
-                    cache-control: no-cache
-                    x-restbase-parentrevision: '{{message.rev_parent_id}}'
-                    if-unmodified-since: '{{date(message.meta.dt)}}'
-                  query:
-                    redirect: false
+                  - method: get
+                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'
+                    headers:
+                      cache-control: no-cache
+                      x-restbase-parentrevision: '{{message.rev_parent_id}}'
+                      if-unmodified-since: '{{date(message.meta.dt)}}'
+                    query:
+                      redirect: false
+                  - method: post
+                    uri: '/sys/links/transcludes/{message.page_title}'
+                    body: '{{globals.message}}'
 
               revision_visibility_change:
                 topic: mediawiki.revision-visibility-change
@@ -297,24 +304,6 @@ spec: &spec
                       cache-control: no-cache
                     query:
                       redirect: false
-
-              transclusion_update:
-                topic: mediawiki.revision-create
-                # Test-only. We use undefined rev_parent_id to test backlinks so we
-                # don't want transclusions to interfere with backlinks test
-                match_not:
-                  - rev_parent_id: undefined
-                  - meta:
-                      domain: /\.wikidata\.org$/
-                    page_namespace: 0
-                  - meta:
-                      domain: /\.wikidata\.org$/
-                    page_namespace: 120
-                # end of test-only config
-                exec:
-                  method: post
-                  uri: '/sys/links/transcludes/{message.page_title}'
-                  body: '{{globals.message}}'
 
               on_transclusion_update:
                 topic: change-prop.transcludes.resource-change

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -19,7 +19,6 @@ describe('Basic rule management', function() {
     let producer;
     let retrySchema;
     let errorSchema;
-    let siteInfoResponse;
 
     before(function() {
         // Setting up might tike some tome, so disable the timeout
@@ -30,18 +29,6 @@ describe('Basic rule management', function() {
         .then((res) => retrySchema = yaml.safeLoad(res.body))
         .then(() => preq.get({ uri: 'https://raw.githubusercontent.com/wikimedia/mediawiki-event-schemas/master/jsonschema/error/1.yaml' }))
         .then((res) => errorSchema = yaml.safeLoad(res.body))
-        .then(() => {
-            preq.post({
-                uri: 'https://en.wikipedia.org/w/api.php',
-                body: {
-                    format: 'json',
-                    action: 'query',
-                    meta: 'siteinfo',
-                    siprop: 'general|namespaces|namespacealiases'
-                }
-            });
-        })
-        .then((res) => siteInfoResponse = res)
         .then(common.factory.createProducer.bind(common.factory))
         .then((result) => producer = result);
     });


### PR DESCRIPTION
Currently, figuring out if a page is transcluded is a separate rule from
page_edit. This means that the transclude process will run even if there
are failures in rendering the new revision in RB/Parsoid. The behaviour
is not ideal in such cases, especially if rendering the original page is
blacklisted in RESTBase. An extreme case has been discovered this
week-end where a user page got edited repeatedly by bot, and as it
happens, that page is transcluded in thousands of other user pages.

By merging these two actions into the page_edit rule we ensure that the
transclusion process will be started only if the initial render
succeeded. This has two important consequences:
- it makes CP respect RESTBase's blacklists (as such requests will not
  be retried)
- it makes CP less prone to overload the system, since the transclusion
  process will not start if RESTBase returns a 5xx for whatever reason