### PR TITLE
Start testing with kafka 0.10 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 
 env:
   - KAFKA_HOME=../kafka KAFKA_VERSION=0.9.0.1 CXX=g++-4.8
+  - KAFKA_HOME=../kafka KAFKA_VERSION=0.10.1.0 CXX=g++-4.8
 
 addons:
   apt:


### PR DESCRIPTION
Kafka 0.10 will bring us a lot of highly needed features, like support for timestamp index and seeking to the timestamp. Obviously, it's too new to update the cluster, and all the nice features are not supported by `librdkafka` of the driver yet, but let's start testing the newer version in travis sooner to build up the confidence when the time for an upgrade comes.

cc @wikimedia/services 