### PR TITLE
Propagate wikidata description change on undo/revert action

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -612,7 +612,7 @@ spec: &spec
                   page_namespace: 0
                   # It's impossible to modify a comment in wikidata while editing the entity.
                   # TODO: This is a temp solution until we get a more general fragment support T148079
-                  comment: '/wbeditentity|wbsetdescription/'
+                  comment: '/wbeditentity|wbsetdescription|undo/'
                 exec:
                   method: post
                   uri: '/sys/links/wikidata_descriptions'


### PR DESCRIPTION
We need to add 'undo' to the regex for detecting Wikidata description
edits so that this type of change event also gets propagated.