### PR TITLE
Disable CP precaching in Wikis where ORES review tool is enabled

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -366,17 +366,6 @@ spec: &spec
                         precache: true
                   - match:
                       meta:
-                        domain: en.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/enwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
                         domain: en.wiktionary.org
                       performer:
                         user_is_bot: false
@@ -406,17 +395,6 @@ spec: &spec
                       uri: 'https://ores.wikimedia.org/v2/scores/etwiki/'
                       query:
                         models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: fa.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/fawiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
                         revids: '{{message.rev_id}}'
                         precache: true
                   - match:
@@ -476,61 +454,6 @@ spec: &spec
                         precache: true
                   - match:
                       meta:
-                        domain: nl.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/nlwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: pl.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/plwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: pt.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/ptwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: ru.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/ruwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: tr.wikipedia.org
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/trwiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
                         domain: uk.wikipedia.org
                       performer:
                         user_is_bot: false
@@ -549,18 +472,6 @@ spec: &spec
                       uri: 'https://ores.wikimedia.org/v2/scores/viwiki/'
                       query:
                         models: 'reverted'
-                        revids: '{{message.rev_id}}'
-                        precache: true
-                  - match:
-                      meta:
-                        domain: www.wikidata.org
-                      page_namespace: 0
-                      performer:
-                        user_is_bot: false
-                    exec:
-                      uri: 'https://ores.wikimedia.org/v2/scores/wikidatawiki/'
-                      query:
-                        models: 'reverted|damaging|goodfaith'
                         revids: '{{message.rev_id}}'
                         precache: true
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -439,9 +439,9 @@ describe('RESTBase update rules', function() {
 
     it('Should update ORES on revision-create', () => {
         const oresService = nock('https://ores.wikimedia.org')
-        .get('/v2/scores/enwiki/')
+        .get('/v2/scores/frwiki/')
         .query({
-            models: 'reverted|damaging|goodfaith',
+            models: 'reverted',
             revids: 1234,
             precache: true })
         .reply(200, { });
@@ -455,7 +455,7 @@ describe('RESTBase update rules', function() {
                     request_id: common.SAMPLE_REQUEST_ID,
                     id: uuid.now(),
                     dt: new Date(1000).toISOString(),
-                    domain: 'en.wikipedia.org'
+                    domain: 'fr.wikipedia.org'
                 },
                 page_title: 'TestPage',
                 rev_id: 1234,


### PR DESCRIPTION
It won't be needed since the extension does the precaching too

Bug: T157206