### PR TITLE
Update node-rdkafka to 0.8.0

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -78,10 +78,16 @@ class BaseExecutor {
 
     _consume() {
         this._consuming = true;
-        this.consumer.consumeAsync()
-        .then((msg) => {
+        this.consumer.consumeAsync(1)
+        .then((messages) => {
             this.hyper.metrics.increment(`${this.statName}_dequeue`, 1, 0.1);
 
+            if (!messages.length) {
+                // No new messages, delay a bit and try again.
+                return P.delay(100);
+            }
+
+            const msg = messages[0];
             const message = this._safeParse(msg.value.toString('utf8'));
             const handler = this.getHandler(message);
             if (handler) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "json-stable-stringify": "^1.0.1",
     "htcp-purge": "^0.2.2",
     "mediawiki-title": "^0.5.6",
-    "node-rdkafka": "^0.6.4",
+    "node-rdkafka": "^0.8.0",
     "node-rdkafka-statsd": "^0.1.0"
   },
   "devDependencies": {

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -169,13 +169,14 @@ describe('Basic rule management', function() {
                 Buffer.from(JSON.stringify(common.eventWithMessageAndRandom('test', random)))), 2000);
 
             function check() {
-                return retryConsumer.consumeAsync()
+                return retryConsumer.consumeAsync(1)
                 .catch(check)
-                .then((message) => {
-                    if (!message) {
+                .then((messages) => {
+                    if (!messages.length) {
                         return;
                     }
 
+                    const message = messages[0];
                     const ajv = new Ajv();
                     const validate = ajv.compile(retrySchema);
                     const msg = JSON.parse(message.value.toString());
@@ -303,16 +304,17 @@ describe('Basic rule management', function() {
                 producer.produce('test_dc.simple_test_rule', 0, Buffer.from('not_a_json_message')), 2000);
 
             function check() {
-                return errorConsumer.consumeAsync()
+                return errorConsumer.consumeAsync(1)
                 .catch(check)
-                .then((message) => {
-                    if (!message) {
+                .then((messages) => {
+                    if (!messages.length) {
                         return;
                     }
 
+                    const message = messages[0];
                     const ajv = new Ajv();
                     const validate = ajv.compile(errorSchema);
-                    var valid = validate(JSON.parse(message.value.toString()));
+                    const valid = validate(JSON.parse(message.value.toString()));
                     if (!valid) {
                         throw  new assert.AssertionError({
                             message: ajv.errorsText(validate.errors)


### PR DESCRIPTION
The new version of of node-rdkafka has been released, and we need to update since it's bringing quite a few improvements and also might let us get rid of the memory leak we've been suffering from with the GuaranteedProducer. It depends on librdkafka 0.9.4 while we have version 0.9.1 installed on our servers. We need to make a joint coordinated update to all services.