### PR TITLE
Prototype of the idea of reporting metrics for RESTBase varnish

### DIFF
--- a/config.example.metrics.yaml
+++ b/config.example.metrics.yaml
@@ -1,0 +1,58 @@
+spec: &spec
+  x-sub-request-filters:
+    - type: default
+      name: http
+      options:
+        allow:
+          - pattern: /^https?:\/\//
+            forward_headers:
+              user-agent: true
+  title: The Change Propagation metrics reporter root
+  paths:
+    /sys/metrics:
+      x-modules:
+        - path: sys/metrics.js
+          options:
+            templates:
+              spec_request:
+                  method: 'get'
+                  uri: 'https://{{message.uri_host}}/api/rest_v1/?spec'
+    /sys/queue:
+      x-modules:
+        - path: sys/kafka.js
+          options:
+            metadata_broker_list: 127.0.0.1:9092
+            dc_name: '' # VarnishKafka topics are not prefixed with a DC name
+            enable_retries: false
+            startup_delay: 0
+            consumer:
+              # These options should not be copied to puppet config.
+              # We're using this config for testing, so need to configure
+              # for minimal latency
+              fetch.wait.max.ms: "1"
+              fetch.min.bytes: "1"
+              queue.buffering.max.ms: "1"
+            concurrency: 250
+            templates:
+              varnish_metrics_collect:
+                topic: webrequest_text
+                match:
+                  uri_path: '/^\/api\/rest_v1/'
+                exec:
+                  method: post
+                  uri: '/sys/metrics/webrequest'
+                  body: '{{globals.message}}'
+
+num_workers: 0
+logging:
+  name: changeprop-metrics
+  level: trace
+metrics:
+  type: log
+services:
+  - name: changeprop-metrics
+    module: hyperswitch
+    conf:
+      port: 7273
+      user_agent: MetricsChangePropInstance
+      spec: *spec

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -26,31 +26,6 @@ spec: &spec
                     host: '{{message.meta.domain}}'
                   body:
                     formatversion: 2
-    /sys/metrics:
-      x-modules:
-        - path: sys/metrics.js
-    /sys/monitoring_queue:
-      x-modules:
-        - path: sys/kafka.js
-          options:
-            metadata_broker_list: 127.0.0.1:9092
-            dc_name: test_dc
-            startup_delay: 0
-            consumer:
-              # These options should not be copied to puppet config.
-              # We're using this config for testing, so need to configure
-              # for minimal latency
-              fetch.wait.max.ms: "1"
-              fetch.min.bytes: "1"
-              queue.buffering.max.ms: "1"
-            concurrency: 250
-            templates:
-              varnish_metrics_collect:
-                topic: webrequest_text
-                exec:
-                  method: post
-                  uri: '/sys/metrics/webrequest'
-                  body: '{{globals.message}}'
     /sys/queue:
       x-modules:
         - path: sys/kafka.js

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -26,6 +26,31 @@ spec: &spec
                     host: '{{message.meta.domain}}'
                   body:
                     formatversion: 2
+    /sys/metrics:
+      x-modules:
+        - path: sys/metrics.js
+    /sys/monitoring_queue:
+      x-modules:
+        - path: sys/kafka.js
+          options:
+            metadata_broker_list: 127.0.0.1:9092
+            dc_name: test_dc
+            startup_delay: 0
+            consumer:
+              # These options should not be copied to puppet config.
+              # We're using this config for testing, so need to configure
+              # for minimal latency
+              fetch.wait.max.ms: "1"
+              fetch.min.bytes: "1"
+              queue.buffering.max.ms: "1"
+            concurrency: 250
+            templates:
+              varnish_metrics_collect:
+                topic: webrequest_text
+                exec:
+                  method: post
+                  uri: '/sys/metrics/webrequest'
+                  body: '{{globals.message}}'
     /sys/queue:
       x-modules:
         - path: sys/kafka.js

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -54,7 +54,7 @@ class BaseExecutor {
 
     subscribe() {
         return this.kafkaFactory.createConsumer(
-            `change-prop-${this.rule.name}`,
+            `change-prop6-${this.rule.name}`,
             this.subscribeTopic,
             this.hyper.metrics
         )
@@ -213,16 +213,19 @@ class BaseExecutor {
             msg: 'Event message received',
             event: utils.stringify(origEvent) }));
 
+        const dt = origEvent.meta && origEvent.meta.dt || origEvent.dt;
         // latency from the original event creation time to execution time
         this.hyper.metrics.endTiming([`${this.statName}_delay`],
-            statDelayStartTime || new Date(origEvent.meta.dt));
+            statDelayStartTime || new Date(dt));
 
         return P.each(handler.exec, (tpl) => {
             const request = tpl.expand(expander);
-            request.headers = Object.assign(request.headers, {
-                'x-request-id': origEvent.meta.request_id,
-                'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
-            });
+            const context = {};
+            if (origEvent.meta) {
+                context['x-request-id'] = origEvent.meta.request_id;
+                context['x-triggered-by'] = utils.triggeredBy(retryEvent || origEvent);
+            }
+            request.headers = Object.assign(request.headers, context);
             return this.hyper.request(request)
             .tap((res) => {
                 if (res.status === 301) {

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -54,7 +54,7 @@ class BaseExecutor {
 
     subscribe() {
         return this.kafkaFactory.createConsumer(
-            `change-prop6-${this.rule.name}`,
+            `change-prop-${this.rule.name}`,
             this.subscribeTopic,
             this.hyper.metrics
         )

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -155,6 +155,9 @@ class KafkaFactory {
      * @returns {string}
      */
     get consumeDC() {
+        if (this._kafkaConf.dc_name === '' || this._kafkaConf.consume_dc === '') {
+            return '';
+        }
         return this._kafkaConf.dc_name || this._kafkaConf.consume_dc || 'datacenter1';
     }
 
@@ -164,7 +167,26 @@ class KafkaFactory {
      * @returns {string}
      */
     get produceDC() {
+        if (this._kafkaConf.dc_name === '' || this._kafkaConf.produce_dc === '') {
+            return '';
+        }
         return this._kafkaConf.dc_name || this._kafkaConf.produce_dc || 'datacenter1';
+    }
+
+    prefixConsumeTopic(topicName) {
+        const consumeDC = this.consumeDC;
+        if (consumeDC === '') {
+            return topicName;
+        }
+        return `${consumeDC}.${topicName}`;
+    }
+
+    prefixProduceTopic(topicName) {
+        const produceDC = this.produceDC;
+        if (produceDC === '') {
+            return topicName;
+        }
+        return `${produceDC}.${topicName}`;
     }
 
     /**

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -9,7 +9,7 @@ const BaseExecutor = require('./base_executor');
  */
 class RetryExecutor extends BaseExecutor {
     get subscribeTopic() {
-        return `${this.kafkaFactory.consumeDC}.${this._retryTopicName()}`;
+        return this.kafkaFactory.prefixConsumeTopic(this._retryTopicName());
     }
 
     get statName() {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -7,7 +7,7 @@ const BaseExecutor = require('./base_executor');
  */
 class RuleExecutor extends BaseExecutor {
     get subscribeTopic() {
-        return `${this.kafkaFactory.consumeDC}.${this.rule.topic}`;
+        return this.kafkaFactory.prefixConsumeTopic(this.rule.topic);
     }
 
     get statName() {

--- a/sys/metrics.js
+++ b/sys/metrics.js
@@ -1,35 +1,70 @@
 "use strict";
 
 const P = require('bluebird');
-const Router = require('hyperswitch').Router;
+const HyperSwitch = require('hyperswitch');
+const stringify = require('json-stable-stringify');
+const Router = HyperSwitch.Router;
+const Template = HyperSwitch.Template;
 
 class MetricsReporter {
     constructor(options) {
-        this._options = options;
+        this._options = options || {};
+        this._options.sample_rate = this._options.sample_rate || 0.01;
+        this._specRequestTemplate = new Template(options.templates.spec_request);
+
         this._router_cache = new Map();
+        this._spec_cache = new Map();
     }
 
-    _getRouter(hyper, domain) {
+    _getRouter(hyper, message) {
+        const domain = message.uri_host;
         if (!this._router_cache.has(domain)) {
-            this._router_cache.set(domain, hyper.get({
-                uri: `http://localhost:7231/${domain}/v1/?spec`
-            })
+            return hyper.get(this._specRequestTemplate.expand({ message }))
             .then((res) => {
-                const router = new Router({
-                    appBasePath: '/api/rest_v1'
-                });
-                return router.loadSpec(res.body, hyper);
-            }));
+                const spec = res.body;
+                const stringSpec = stringify(spec);
+
+                let sameSpecDomain;
+                for (const entry of this._spec_cache.entries()) {
+                    if (entry[1] === stringSpec) {
+                        sameSpecDomain = entry[0];
+                        break;
+                    }
+                }
+
+                let router;
+
+                if (sameSpecDomain) {
+                    router = this._router_cache.get(sameSpecDomain);
+                    this._router_cache.set(domain, router);
+                } else {
+                    this._spec_cache.set(domain, stringSpec);
+                    router = new Router({
+                        appBasePath: '/api/rest_v1',
+                        disable_handlers: true
+                    });
+                    router = router.loadSpec(spec, hyper);
+                    this._router_cache.set(domain, P.resolve(router));
+                }
+                return router;
+            });
         }
         return this._router_cache.get(domain);
     }
 
     webrequest(hyper, req) {
         const message = req.body;
-        return this._getRouter(hyper, message.uri_host)
+        return this._getRouter(hyper, message)
         .then((router) => {
             const handler = router.route(message.uri_path.replace(/^\/api\/rest_v1/, ''));
-            console.log(handler.value.path);
+            const path = handler.value.path;
+            let statName = `${path}.${message.http_method.toUpperCase()}.`;
+            // Normalize invalid chars
+            statName = hyper.metrics.normalizeName(statName);
+            hyper.metrics.increment(statName, 1, this._options.sample_rate);
+        })
+        .catch((e) => {
+            // Ignore all errors, don't want to die or retry
         })
         .thenReturn({ status: 200 });
     }

--- a/sys/metrics.js
+++ b/sys/metrics.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const P = require('bluebird');
+const Router = require('hyperswitch').Router;
+
+class MetricsReporter {
+    constructor(options) {
+        this._options = options;
+        this._router_cache = new Map();
+    }
+
+    _getRouter(hyper, domain) {
+        if (!this._router_cache.has(domain)) {
+            this._router_cache.set(domain, hyper.get({
+                uri: `http://localhost:7231/${domain}/v1/?spec`
+            })
+            .then((res) => {
+                const router = new Router({
+                    appBasePath: '/api/rest_v1'
+                });
+                return router.loadSpec(res.body, hyper);
+            }));
+        }
+        return this._router_cache.get(domain);
+    }
+
+    webrequest(hyper, req) {
+        const message = req.body;
+        return this._getRouter(hyper, message.uri_host)
+        .then((router) => {
+            const handler = router.route(message.uri_path.replace(/^\/api\/rest_v1/, ''));
+            console.log(handler.value.path);
+        })
+        .thenReturn({ status: 200 });
+    }
+}
+
+module.exports = (options) => {
+    const processor = new MetricsReporter(options);
+    return {
+        spec: {
+            paths: {
+                '/webrequest': {
+                    post: {
+                        summary: 'report a request REST API',
+                        operationId: 'webrequest'
+                    }
+                }
+            }
+        },
+        operations: {
+            webrequest: processor.webrequest.bind(processor)
+        }
+    };
+};


### PR DESCRIPTION
In order to better isolate, we can run this metrics reporting code in a separate instance of change-prop, thus the new config file. 

Added support for non-prefixed topic names, switching off retries whatsoever. The metrics module is caching the routers, and if the specs on multiple domains are the same, the routers are reused. Sampling 1% by default, but that's configurable. 

cc @wikimedia/services 