### PR TITLE
Created autopolling producer

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -40,6 +40,8 @@ spec: &spec
               fetch.wait.max.ms: "1"
               fetch.min.bytes: "1"
               queue.buffering.max.ms: "1"
+            producer:
+              queue.buffering.max.messages: "10"
             concurrency: 250
             templates:
 

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -36,16 +36,16 @@ class GuaranteedProducer extends kafka.Producer {
     /**
      * @inheritDoc
      */
-    constructor(conf, topicConf, logger) {
+    constructor(conf, topicConf, log) {
         super(conf, topicConf);
-        this._logger = logger;
+        this._log = log;
         this._pending = {};
 
         this.on('delivery-report', (report) => {
             const reportKey = `${report.topic}:${report.key}`;
             const resolve = this._pending[reportKey];
             if (!resolve) {
-                this._logger.log('error/produce', {
+                this._log('error/produce', {
                     message: 'Unknown resolver in delivery report',
                     report
                 });
@@ -106,6 +106,34 @@ class GuaranteedProducer extends kafka.Producer {
 
 }
 /*eslint-enable */
+
+class AutopollingProducer extends kafka.Producer {
+    constructor(config, topicConfig, log) {
+        super(config, topicConfig);
+        this.on('error', (e) => log('error/producer', {
+            msg: 'Producer error', e
+        }));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    produce(topic, partition, message, key) {
+        return new P((resolve, reject) => {
+            try {
+                const result = super.produce(topic, partition, message, key);
+                if (result !== true) {
+                    return reject(result);
+                }
+                return resolve(result);
+            } catch (e) {
+                return reject(e);
+            } finally {
+                this.poll();
+            }
+        });
+    }
+}
 
 class KafkaFactory {
     /**
@@ -207,12 +235,12 @@ class KafkaFactory {
         });
     }
 
-    _createProducerOfClass(ProducerClass, logger) {
+    _createProducerOfClass(ProducerClass, log) {
         return new P((resolve, reject) => {
             const producer = new ProducerClass(
                 this._producerConf,
                 this._producerTopicConf,
-                logger || (() => {})
+                log || (() => {})
             );
             producer.once('error', reject);
             producer.connect(undefined, (err) => {
@@ -225,12 +253,12 @@ class KafkaFactory {
 
     }
 
-    createProducer(logger) {
-        return this._createProducerOfClass(kafka.Producer, logger);
+    createProducer(log) {
+        return this._createProducerOfClass(AutopollingProducer, log);
     }
 
-    createGuaranteedProducer(logger) {
-        return this._createProducerOfClass(kafka.Producer, logger);
+    createGuaranteedProducer(log) {
+        return this._createProducerOfClass(AutopollingProducer, log);
     }
 }
 module.exports = KafkaFactory;

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -91,8 +91,6 @@ class Kafka {
             const topicName = message.meta.topic.replace(/\./g, '_');
             hyper.metrics.increment(`produce_${hyper.metrics.normalizeName(topicName)}`);
 
-            // TODO: This has to return a promise for guaranteed producer.
-            // TODO: This is a quick fix to be rewritten.
             return this.producer.produce(`${this.kafkaFactory.produceDC}.${message.meta.topic}`, 0,
                 Buffer.from(JSON.stringify(message)));
         }))

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -93,9 +93,8 @@ class Kafka {
 
             // TODO: This has to return a promise for guaranteed producer.
             // TODO: This is a quick fix to be rewritten.
-            this.producer.produce(`${this.kafkaFactory.produceDC}.${message.meta.topic}`, 0,
+            return this.producer.produce(`${this.kafkaFactory.produceDC}.${message.meta.topic}`, 0,
                 Buffer.from(JSON.stringify(message)));
-            return this.producer.poll();
         }))
         .thenReturn({ status: 201 });
     }

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -29,7 +29,7 @@ describe('Basic rule management', function() {
         .then((res) => retrySchema = yaml.safeLoad(res.body))
         .then(() => preq.get({ uri: 'https://raw.githubusercontent.com/wikimedia/mediawiki-event-schemas/master/jsonschema/error/1.yaml' }))
         .then((res) => errorSchema = yaml.safeLoad(res.body))
-        .then(common.factory.createProducer.bind(common.factory))
+        .then(() => common.factory.createProducer(console.log.bind(console)))
         .then((result) => producer = result);
     });
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -35,7 +35,7 @@ describe('RESTBase update rules', function() {
             });
         })
         .then((res) => siteInfoResponse = res.body)
-        .then(() =>  common.factory.createProducer())
+        .then(() => common.factory.createProducer(console.log.bind(console)))
         .then((result) => producer = result);
     });
 


### PR DESCRIPTION
Better encapsulation of `poll` call and better promise rejection handling. Also for testing decreased the side of the buffer - if poll is not called correctly tests would start failing.

cc @wikimedia/services 