### PR TITLE
Switch to guaranteed producer using opaque

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -48,7 +48,7 @@ class GuaranteedProducer extends kafka.Producer {
         });
 
         this.on('ready', () => {
-            this._pollInterval = setInterval(() => this.poll(), 100);
+            this._pollInterval = setInterval(() => this.poll(), 10);
         });
     }
 
@@ -72,6 +72,8 @@ class GuaranteedProducer extends kafka.Producer {
                 process.nextTick(() => {
                     reject(e);
                 });
+            } finally {
+                this.poll();
             }
         });
     }

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -24,11 +24,11 @@ const CONSUMER_TOPIC_DEFAULTS = {
 };
 
 const PRODUCER_DEFAULTS = {
-    // dr_cb: true
+    dr_cb: true
 };
 
 const PRODUCER_TOPIC_DEFAULTS = {
-    // 'request.required.acks': 1
+    'request.required.acks': 1
 };
 
 /*eslint-disable */
@@ -36,27 +36,20 @@ class GuaranteedProducer extends kafka.Producer {
     /**
      * @inheritDoc
      */
-    constructor(conf, topicConf, log) {
+    constructor(conf, topicConf) {
         super(conf, topicConf);
-        this._log = log;
-        this._pending = {};
 
-        this.on('delivery-report', (report) => {
-            const reportKey = `${report.topic}:${report.key}`;
-            const resolve = this._pending[reportKey];
-            if (!resolve) {
-                this._log('error/produce', {
-                    message: 'Unknown resolver in delivery report',
-                    report
-                });
-                return;
+        this.on('delivery-report', (err, report) => {
+            const reporter = report.opaque;
+            if (err) {
+                return reporter.rejecter(err);
             }
-
-            delete this._pending[reportKey];
-            resolve(report);
+            return reporter.resolver(report);
         });
 
-        this._pollInterval = setInterval(() => this.poll(), 500);
+        this.on('ready', () => {
+            this._pollInterval = setInterval(() => this.poll(), 100);
+        });
     }
 
     /**
@@ -64,32 +57,19 @@ class GuaranteedProducer extends kafka.Producer {
      */
     produce(topic, partition, message, key) {
         return new P((resolve, reject) => {
-            if (!key) {
-                process.nextTick(() =>
-                    reject(new Error('Key is required for guaranteed delivery')));
-                return;
-            }
-
-            const reportKey = `${topic}:${key}`;
-
-            if (this._pending[reportKey]) {
-                process.nextTick(() => reject(new Error(`Duplicate key: ${reportKey}`)));
-                return;
-            }
-
-            this._pending[reportKey] = resolve;
-
+            const report = {
+                resolver: resolve,
+                rejecter: reject
+            };
             try {
-                const result = super.produce(topic, partition, message, key);
+                const result = super.produce(topic, partition, message, key, undefined, report);
                 if (result !== true) {
                     process.nextTick(() => {
-                        delete this._pending[reportKey];
                         reject(result);
                     });
                 }
             } catch (e) {
                 process.nextTick(() => {
-                    delete this._pending[reportKey];
                     reject(e);
                 });
             }
@@ -100,7 +80,9 @@ class GuaranteedProducer extends kafka.Producer {
      * @inheritDoc
      */
     disconnect(cb) {
-        clearInterval(this._pollInterval);
+        if (this._pollInterval) {
+            clearInterval(this._pollInterval);
+        }
         return super.disconnect(cb);
     }
 
@@ -258,7 +240,7 @@ class KafkaFactory {
     }
 
     createGuaranteedProducer(log) {
-        return this._createProducerOfClass(AutopollingProducer, log);
+        return this._createProducerOfClass(GuaranteedProducer, log);
     }
 }
 module.exports = KafkaFactory;

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -92,7 +92,7 @@ class Kafka {
             hyper.metrics.increment(`produce_${hyper.metrics.normalizeName(topicName)}`);
 
             return this.producer.produce(`${this.kafkaFactory.produceDC}.${message.meta.topic}`, 0,
-                Buffer.from(JSON.stringify(message)), message.meta.id);
+                Buffer.from(JSON.stringify(message)));
         }))
         .thenReturn({ status: 201 });
     }

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -92,7 +92,7 @@ class Kafka {
             hyper.metrics.increment(`produce_${hyper.metrics.normalizeName(topicName)}`);
 
             return this.producer.produce(`${this.kafkaFactory.produceDC}.${message.meta.topic}`, 0,
-                Buffer.from(JSON.stringify(message)));
+                Buffer.from(JSON.stringify(message)), message.meta.id);
         }))
         .thenReturn({ status: 201 });
     }


### PR DESCRIPTION
Attempt number 3.

The newest version of the kafka driver support a message `opaque` feature. In C++ land it's basically attaching an arbitrary pointer to the message and then returns the pointer together with a delivery report. Node driver supports providing an arbitrary Javascript object, pointer to which would be used as an opaque in C++ land, so we can get back the same exact object. Since the object in JS land gets out of the scope and might be GCed normally, driver uses native `Nan::Persistent` in order to hold on to the object while it's in the C++ land and resets the persistent before passing it back to JS land.

Using this feature we now can pass promise `resolve` and `reject` functions through native code, get them back in the delivery report and call them which makes guaranteed producer implementation so much easier (and scarier)

I've verified the driver code around this new feature we're adopting and done very extensive memory-leaks testing - locally all runs fine. Doesn't guarantee we won't have a memory leak in production again though..

Also, this version doesn't `poll` on each and every produce call, but polls once in 100 ms instead. It is a bit riskier, but the buffer size is 100.000 messages and I don't think we'd ever produce fast enough to overflow the buffer.

cc @wikimedia/services 