### PR TITLE
Support regexes topics and refactor subscription process

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -46,7 +46,7 @@ spec: &spec
             templates:
 
               summary_definition_rerender: &summary_definition_rerender_spec
-                topic: '/^(:?change-prop\.transcludes\.)?resource[-_]change$/'
+                topic: '/^(?:change-prop\.transcludes\.)?resource[-_]change$/'
                 retry_limit: 2
                 retry_delay: 500
                 retry_on:
@@ -89,7 +89,7 @@ spec: &spec
                         cache-control: no-cache
 
               mobile_rerender: &mobile_rerender_spec
-                topic: '/^(:?change-prop\.transcludes\.)?resource[-_]change$/'
+                topic: '/^(?:change-prop\.transcludes\.)?resource[-_]change$/'
                 retry_limit: 2
                 retry_delay: 500
                 retry_on:
@@ -112,7 +112,7 @@ spec: &spec
                     cache-control: no-cache
 
               purge_varnish: &purge_varnish_spec
-                topic: '/^(:?change-prop\.transcludes\.)?resource[-_]change$/'
+                topic: '/^(?:change-prop\.transcludes\.)?resource[-_]change$/'
                 match:
                   meta:
                     uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(?<title>.+)$/'

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -46,7 +46,7 @@ spec: &spec
             templates:
 
               summary_definition_rerender: &summary_definition_rerender_spec
-                topic: resource_change
+                topic: '/^(:?change-prop\.transcludes\.)?resource[-_]change$/'
                 retry_limit: 2
                 retry_delay: 500
                 retry_on:
@@ -88,12 +88,8 @@ spec: &spec
                       headers:
                         cache-control: no-cache
 
-              summary_definition_rerender_transcludes:
-                <<: *summary_definition_rerender_spec
-                topic: change-prop.transcludes.resource-change
-
               mobile_rerender: &mobile_rerender_spec
-                topic: resource_change
+                topic: '/^(:?change-prop\.transcludes\.)?resource[-_]change$/'
                 retry_limit: 2
                 retry_delay: 500
                 retry_on:
@@ -115,12 +111,8 @@ spec: &spec
                   headers:
                     cache-control: no-cache
 
-              mobile_rerender_transcludes:
-                <<: *mobile_rerender_spec
-                topic: change-prop.transcludes.resource-change
-
               purge_varnish: &purge_varnish_spec
-                topic: resource_change
+                topic: '/^(:?change-prop\.transcludes\.)?resource[-_]change$/'
                 match:
                   meta:
                     uri: '/^https?:\/\/[^\/]+\/api\/rest_v1\/(?<title>.+)$/'
@@ -132,10 +124,6 @@ spec: &spec
                   body:
                     - meta:
                         uri: '//{{message.meta.domain}}/api/rest_v1/{{match.meta.uri.title}}'
-
-              purge_varnish_transcludes:
-                <<: *purge_varnish_spec
-                topic: change-prop.transcludes.resource-change
 
               # RESTBase update jobs
               mw_purge:

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -149,6 +149,7 @@ class MetadataWatch extends EventEmitter {
     }
 
     getTopics() {
+        const dcRemoveRegex = new RegExp(`^${this._consumeDC}\\.`);
         return new P((resolve, reject) => {
             this._consumer.getMetadata(undefined, (err, res) => {
                 if (err) {
@@ -158,7 +159,7 @@ class MetadataWatch extends EventEmitter {
                     topicInfo.name.startsWith(this._consumeDC))
                 .map((topicInfo) => {
                     if (this._consumeDC) {
-                        return topicInfo.name.replace(`${this._consumeDC}.`, '');
+                        return topicInfo.name.replace(dcRemoveRegex, '');
                     }
                     return topicInfo.name;
                 }));

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -2,6 +2,7 @@
 
 const kafka = require('node-rdkafka');
 const P = require('bluebird');
+const EventEmitter = require('events').EventEmitter;
 const rdKafkaStatsdCb = require('node-rdkafka-statsd');
 
 /**
@@ -31,7 +32,6 @@ const PRODUCER_TOPIC_DEFAULTS = {
     'request.required.acks': 1
 };
 
-/*eslint-disable */
 class GuaranteedProducer extends kafka.Producer {
     /**
      * @inheritDoc
@@ -89,7 +89,6 @@ class GuaranteedProducer extends kafka.Producer {
     }
 
 }
-/*eslint-enable */
 
 class AutopollingProducer extends kafka.Producer {
     constructor(config, topicConfig, log) {
@@ -116,6 +115,62 @@ class AutopollingProducer extends kafka.Producer {
                 this.poll();
             }
         });
+    }
+}
+
+class MetadataWatch extends EventEmitter {
+    constructor(consumer, consumeDC) {
+        super();
+        this._consumer = consumer;
+        this._knownTopics = [];
+        this._refreshInterval = undefined;
+        this._consumeDC = consumeDC;
+    }
+
+    _setup() {
+        return this.getTopics()
+        .then((topics) => {
+            this._knownTopics = topics;
+            this._refreshInterval = setInterval(() => {
+                this.getTopics()
+                .then((topics) => {
+                    // TODO:emit info when topic is removed (although it's impossible in prod)
+                    topics.forEach((newTopic) => {
+                        if (this._knownTopics.indexOf(newTopic) < 0) {
+                            this.emit('topic_added', newTopic);
+                        }
+                    });
+                    this._knownTopics = topics;
+                });
+                // TODO: make configurable
+            }, 10000);
+        })
+        .thenReturn(this);
+    }
+
+    getTopics() {
+        return new P((resolve, reject) => {
+            this._consumer.getMetadata(undefined, (err, res) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(res.topics.filter((topicInfo) =>
+                    topicInfo.name.startsWith(this._consumeDC))
+                .map((topicInfo) => {
+                    if (this._consumeDC) {
+                        return topicInfo.name.replace(`${this._consumeDC}.`, '');
+                    }
+                    return topicInfo.name;
+                }));
+            });
+        });
+    }
+
+    disconnect() {
+        if (this._refreshInterval) {
+            clearInterval(this._refreshInterval);
+        }
+        return this._consumer.disconnect();
     }
 }
 
@@ -217,6 +272,23 @@ class KafkaFactory {
                 resolve(P.promisifyAll(consumer));
             });
         });
+    }
+
+    createMetadataWatch(groupId) {
+        const conf = Object.assign({}, this._consumerConf);
+        conf['group.id'] = groupId;
+        conf['client.id'] = `${Math.floor(Math.random() * 1000000)}`;
+
+        return new P((resolve, reject) => {
+            const consumer = new kafka.KafkaConsumer(conf, this._consumerTopicConf);
+            consumer.connect(undefined, (err) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(consumer);
+            });
+        })
+        .then((consumer) => new MetadataWatch(consumer, this.consumeDC)._setup());
     }
 
     _createProducerOfClass(ProducerClass, log) {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -135,10 +135,18 @@ class Rule {
         this.name = name;
         this.spec = spec || {};
 
-        this.topic = this.spec.topic;
-        if (!this.topic) {
+        const  topic = this.spec.topic;
+        if (!topic || typeof topic !== 'string' || !topic.length) {
             throw new Error(`No topic specified for rule ${this.name}`);
         }
+
+        if (/^\/.+\//.test(topic)) {
+            // Ok, we've got a regex topic! Compile the regex.
+            this.topic = new RegExp(topic.substring(1, topic.length - 1));
+        } else {
+            this.topic = topic;
+        }
+
         this.spec.retry_on = this.spec.retry_on || {
             status: [ '50x' ]
         };
@@ -162,6 +170,10 @@ class Rule {
                 match_not: this._processMatchNot(option.match_not)
             };
         });
+    }
+
+    isRegexRule() {
+        return this.topic instanceof RegExp;
     }
 
     _processMatchNot(matchNot) {
@@ -259,6 +271,13 @@ class Rule {
             templates.push(new Template(req));
         }
         return templates;
+    }
+
+    clone(newTopic) {
+        const newSpec = Object.assign({}, this.spec);
+        const newName = `${newSpec.name}-${newTopic}`;
+        newSpec.topic = newTopic;
+        return new Rule(newName, newSpec);
     }
 }
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -140,7 +140,7 @@ class Rule {
             throw new Error(`No topic specified for rule ${this.name}`);
         }
 
-        if (/^\/.+\//.test(topic)) {
+        if (/^\/.+\/$/.test(topic)) {
             // Ok, we've got a regex topic! Compile the regex.
             this.topic = new RegExp(topic.substring(1, topic.length - 1));
         } else {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -275,7 +275,7 @@ class Rule {
 
     clone(newTopic) {
         const newSpec = Object.assign({}, this.spec);
-        const newName = `${newSpec.name}-${newTopic}`;
+        const newName = `${this.name}-${newTopic}`;
         newSpec.topic = newTopic;
         return new Rule(newName, newSpec);
     }

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -9,6 +9,7 @@ class BasicSubscription {
         this._kafkaFactory = kafkaFactory;
         this._options = options;
         this._log = this._options.log || (() => {});
+        this._rule = rule;
 
         this._subscribed = false;
         this._executor = new RuleExecutor(rule, this._kafkaFactory,
@@ -21,6 +22,13 @@ class BasicSubscription {
         if (this._subscribed) {
             throw new Error('Already subscribed!');
         }
+
+        this._log('info/subscription', {
+            message: 'Subscribing based on basic topic',
+            rule: this._rule.name,
+            topic: this._rule.topic
+        });
+
         return P.join(this._executor.subscribe(), this._retryExecutor.subscribe())
         .tap(() => {
             this._subscribed = true;
@@ -44,9 +52,11 @@ class RegexTopicSubscription {
         this._rule = rule;
         this._metadataWatch = metadataWatch;
         this._metadataWatch.on('topic_added', (topic) => {
-            // TODO: if the topic was created by CP and
-            // we already have subscriptions to it - don't resubscribe.
             if (this._rule.topic.test(topic)) {
+                this._log('info/topic_added', {
+                    message: 'New topic detected. Subscribing.',
+                    rule: this._rule.name
+                });
                 this._subscribeTopic(topic);
             }
         });
@@ -58,7 +68,12 @@ class RegexTopicSubscription {
     _subscribeTopic(topicName) {
         const topicRule = this._rule.clone(topicName);
 
-        console.log(topicRule);
+        this._log('info/subscription', {
+            message: 'Subscribing based on regex',
+            rule: this._rule.name,
+            topic: topicName
+        });
+
         const executor = new RuleExecutor(topicRule, this._kafkaFactory,
             this._hyper, this._log, this._options);
         this._executors.push(executor);

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -1,0 +1,139 @@
+"use strict";
+
+const RuleExecutor = require('./rule_executor');
+const RetryExecutor = require('./retry_executor');
+const P = require('bluebird');
+
+class BasicSubscription {
+    constructor(options, kafkaFactory, hyper, rule) {
+        this._kafkaFactory = kafkaFactory;
+        this._options = options;
+        this._log = this._options.log || (() => {});
+
+        this._subscribed = false;
+        this._executor = new RuleExecutor(rule, this._kafkaFactory,
+            hyper, this._log, this._options);
+        this._retryExecutor = new RetryExecutor(rule, this._kafkaFactory,
+            hyper, this._log, this._options);
+    }
+
+    subscribe() {
+        if (this._subscribed) {
+            throw new Error('Already subscribed!');
+        }
+        return P.join(this._executor.subscribe(), this._retryExecutor.subscribe())
+        .tap(() => {
+            this._subscribed = true;
+        });
+    }
+
+    unsubscribe() {
+        if (this._subscribed) {
+            this._executor.close();
+            this._retryExecutor.close();
+        }
+    }
+}
+
+class RegexTopicSubscription {
+    constructor(options, kafkaFactory, hyper, rule, metadataWatch) {
+        this._kafkaFactory = kafkaFactory;
+        this._options = options;
+        this._log = this._options.log || (() => {});
+        this._hyper = hyper;
+        this._rule = rule;
+        this._metadataWatch = metadataWatch;
+        this._metadataWatch.on('topic_added', (topic) => {
+            // TODO: if the topic was created by CP and
+            // we already have subscriptions to it - don't resubscribe.
+            if (this._rule.topic.test(topic)) {
+                this._subscribeTopic(topic);
+            }
+        });
+
+        this._subscribed = false;
+        this._executors = [];
+    }
+
+    _subscribeTopic(topicName) {
+        const topicRule = this._rule.clone(topicName);
+
+        console.log(topicRule);
+        const executor = new RuleExecutor(topicRule, this._kafkaFactory,
+            this._hyper, this._log, this._options);
+        this._executors.push(executor);
+
+        const retryExecutor = new RetryExecutor(topicRule, this._kafkaFactory,
+            this._hyper, this._log, this._options);
+        this._executors.push(retryExecutor);
+
+        return P.join(executor.subscribe(), retryExecutor.subscribe())
+        .tap(() => {
+            this._subscribed = true;
+        });
+    }
+
+    subscribe() {
+        return this._metadataWatch.getTopics()
+        .then((topics) => {
+            const selectedTopics = topics.filter((topic) => this._rule.topic.test(topic));
+
+            return P.each(selectedTopics, (topicName) => {
+                return this._subscribeTopic(topicName);
+            });
+        });
+    }
+
+    unsubscribe() {
+        if (this._subscribed) {
+            this._executors.forEach((executor) => executor.close());
+        }
+    }
+}
+
+class Subscriber {
+    constructor(options, kafkaFactory) {
+        this._kafkaFactory = kafkaFactory;
+        this._options = options;
+
+        this._subscriptions = [];
+        this._metadataWatch = undefined;
+    }
+
+    _createSubscription(hyper, rule) {
+        if (rule.isRegexRule()) {
+            let maybeCreateWatchAction;
+            if (!this._metadataWatch) {
+                maybeCreateWatchAction =
+                    this._kafkaFactory.createMetadataWatch('metadata_refresher')
+                .tap((refresher) => {
+                    this._metadataWatch = refresher;
+                });
+            } else {
+                maybeCreateWatchAction = P.resolve(this._metadataWatch);
+            }
+
+            return maybeCreateWatchAction
+            .then(() => new RegexTopicSubscription(this._options, this._kafkaFactory,
+                   hyper, rule, this._metadataWatch));
+        }
+        return P.resolve(new BasicSubscription(this._options, this._kafkaFactory, hyper, rule));
+    }
+
+    subscribe(hyper, rule) {
+        return this._createSubscription(hyper, rule)
+        .then((subscription) => {
+            this._subscriptions.push(subscription);
+            return subscription.subscribe();
+        });
+    }
+
+    unsubscribeAll() {
+        this._subscriptions.forEach((subscription) => subscription.unsubscribe());
+        if (this._metadataWatch) {
+            this._metadataWatch.disconnect();
+        }
+    }
+}
+
+module.exports = Subscriber;

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -53,10 +53,6 @@ class RegexTopicSubscription {
         this._metadataWatch = metadataWatch;
         this._metadataWatch.on('topic_added', (topic) => {
             if (this._rule.topic.test(topic)) {
-                this._log('info/topic_added', {
-                    message: 'New topic detected. Subscribing.',
-                    rule: this._rule.name
-                });
                 this._subscribeTopic(topic);
             }
         });
@@ -116,23 +112,24 @@ class Subscriber {
     }
 
     _createSubscription(hyper, rule) {
-        if (rule.isRegexRule()) {
-            let maybeCreateWatchAction;
-            if (!this._metadataWatch) {
-                maybeCreateWatchAction =
-                    this._kafkaFactory.createMetadataWatch('metadata_refresher')
+        if (!rule.isRegexRule()) {
+            return P.resolve(new BasicSubscription(this._options,
+                this._kafkaFactory, hyper, rule));
+        }
+        let maybeCreateWatchAction;
+        if (!this._metadataWatch) {
+            maybeCreateWatchAction =
+                this._kafkaFactory.createMetadataWatch('metadata_refresher')
                 .tap((refresher) => {
                     this._metadataWatch = refresher;
                 });
-            } else {
-                maybeCreateWatchAction = P.resolve(this._metadataWatch);
-            }
-
-            return maybeCreateWatchAction
-            .then(() => new RegexTopicSubscription(this._options, this._kafkaFactory,
-                   hyper, rule, this._metadataWatch));
+        } else {
+            maybeCreateWatchAction = P.resolve(this._metadataWatch);
         }
-        return P.resolve(new BasicSubscription(this._options, this._kafkaFactory, hyper, rule));
+
+        return maybeCreateWatchAction
+        .then(() => new RegexTopicSubscription(this._options, this._kafkaFactory,
+            hyper, rule, this._metadataWatch));
     }
 
     subscribe(hyper, rule) {

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -37,7 +37,7 @@ ChangeProp.prototype.start = function() {
 
     return this._runner.start(this._config)
     .tap(() => this._running = true)
-    .delay(5000)
+    .delay(15000)
     .catch((e) => {
         if (startupRetryLimit > 0 && /EADDRINUSE/.test(e.message)) {
             console.log('Execution of the previous test might have not finished yet. Retry startup');

--- a/test/utils/clean_kafka.sh
+++ b/test/utils/clean_kafka.sh
@@ -39,7 +39,7 @@ createTopic "test_dc.change-prop.retry.change-prop.backlinks.resource-change"
 createTopic "test_dc.mediawiki.page-properties-change"
 createTopic "test_dc.change-prop.retry.mediawiki.page-properties-change"
 createTopic "test_dc.change-prop.wikidata.resource-change"
-createTopic "test_dc.change-prop.retry.test_dc.change-prop.wikidata.resource-change"
+createTopic "test_dc.change-prop.retry.change-prop.wikidata.resource-change"
 
 wait
 sleep 5

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -83,7 +83,7 @@ common.EN_SITE_INFO_RESPONSE = {
 };
 
 common.checkAPIDone = (api, maxAttempts) => {
-    maxAttempts = maxAttempts || 20;
+    maxAttempts = maxAttempts || 50;
     let attempts = 0;
     const check = () => {
         if (api.isDone()) {


### PR DESCRIPTION
A little pet project of mine finally got working.

This idea is to support regexes in topic property of the rule definition for rules that should listen to different topics but do exactly the same work. Right now we can use them for the `transcodes` topics - the ones we're using to offload summary/mobile defenders generated by template updates and priorities re renders that we're doing for normal edits. Right now it's not super-required feature, but it's a step towards the JobQueue yearly goal and deploying this early can give us a good change to test it and debug this piece before hand.

Also, a little refactoring to abstract out the notion of a subscription which contains of 2 executors (normal and retry) for normal rules and many executors for regexes rules.

cc @wikimedia/services 
Bug: https://phabricator.wikimedia.org/T157093