### PR TITLE
Increase the log level for 'retry count exceeded messages

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -289,9 +289,11 @@ class BaseExecutor {
      */
     _isLimitExceeded(message, e) {
         if (message.retries_left <= 0) {
-            this.log(`info/${this.rule.name}`, () => ({
+            this.log(`warn/${this.rule.name}`, () => ({
                 message: 'Retry count exceeded',
                 event: utils.stringify(message),
+                status: e.status,
+                page: message.meta.uri,
                 description: `${e}`
             }));
             return true;


### PR DESCRIPTION
We want these messages in logstash. Having them we would be able to could a visualization that will show us the most problematic articles in real time, should be pretty cool.

cc @wikimedia/services 