### PR TITLE
Rename the 'event' field to avoid type conflicts in ElasticSearch

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -177,7 +177,7 @@ class BaseExecutor {
                 // no match, drop the message
                 this.log(`debug/${this.rule.name}`, () => ({
                     msg: 'Dropping event message',
-                    event: utils.stringify(event)
+                    event_str: utils.stringify(event)
                 }));
             }
             return optionIndex;
@@ -191,7 +191,7 @@ class BaseExecutor {
         const sampleLog = () => {
             const log = {
                 message: 'Processed event sample',
-                event: utils.stringify(event),
+                event_str: utils.stringify(event),
                 request,
                 response: {
                     status: res.status,
@@ -217,7 +217,7 @@ class BaseExecutor {
 
         this.log(`trace/${rule.name}`, () => ({
             msg: 'Event message received',
-            event: utils.stringify(origEvent) }));
+            event_str: utils.stringify(origEvent) }));
 
         // latency from the original event creation time to execution time
         this.hyper.metrics.endTiming([`${this.statName}_delay`],
@@ -237,7 +237,7 @@ class BaseExecutor {
                     this.log(`warn/${this.rule.name}`, () => ({
                         message: '301 redirect received, used a non-normalized title',
                         rule: this.rule.name,
-                        event: utils.stringify(origEvent)
+                        event_str: utils.stringify(origEvent)
                     }));
                 }
             })
@@ -291,7 +291,7 @@ class BaseExecutor {
         if (message.retries_left <= 0) {
             this.log(`warn/${this.rule.name}`, () => ({
                 message: 'Retry count exceeded',
-                event: utils.stringify(message),
+                event_str: utils.stringify(message),
                 status: e.status,
                 page: message.meta.uri,
                 description: `${e}`
@@ -314,7 +314,7 @@ class BaseExecutor {
                 message: 'Internal error in change-prop',
                 description: `${e}`,
                 stack: e.stack,
-                event: utils.stringify(message)
+                event_str: utils.stringify(message)
             }));
             return reportError();
         }

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -231,7 +231,7 @@ class DependencyProcessor {
             if (res.body && res.body.error) {
                 this.log('warn/wikidata_description', () => ({
                     msg: 'Could not extract items',
-                    event: utils.stringify(context.message),
+                    event_str: utils.stringify(context.message),
                     error: res.body.error
                 }));
             }

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -82,7 +82,7 @@ class Kafka {
                     body: {
                         type: 'bad_request',
                         detail: 'Event must have a meta.topic and meta.id properties',
-                        event: message
+                        event_str: message
                     }
                 });
             }

--- a/sys/purge.js
+++ b/sys/purge.js
@@ -38,7 +38,7 @@ class PurgeService {
             if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri)) {
                 hyper.log('error/events/purge', () => ({
                     message: 'Invalid event URI',
-                    event: utils.stringify(event)
+                    event_str: utils.stringify(event)
                 }));
                 return undefined;
             }


### PR DESCRIPTION
Some other service already mapped the `event` field into the object, so providing a string fails in ElasticSearch. We wanna provide the string because events are pretty arbitrary and we might get unexpected type conflicts yet again.

cc @wikimedia/services 