### PR TITLE
General-purpose rate-limiting with Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
   - KAFKA_HOME=../kafka KAFKA_VERSION=0.9.0.1 CXX=g++-4.8
   - KAFKA_HOME=../kafka KAFKA_VERSION=0.10.1.0 CXX=g++-4.8
 
+services:
+  - redis-server
+
 addons:
   apt:
     sources:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -181,7 +181,7 @@ spec: &spec
               page_edit:
                 topic: mediawiki.revision-create
                 limiters:
-                  blacklist: '{message.page_title}'
+                  blacklist: '{message.meta.uri}'
                 retry_on:
                   status:
                     - '5xx'
@@ -315,14 +315,14 @@ spec: &spec
 
               on_transclusion_update:
                 topic: change-prop.transcludes.resource-change
+                limiters:
+                  blacklist: '{message.meta.uri}'
                 cases:
                   - match:
                       meta:
                         schema_uri: 'resource_change/1'
                         uri: '/https?:\/\/[^\/]+\/wiki\/(?<title>.+)/'
                       tags: [ 'transcludes' ]
-                    limiters:
-                      blacklist: '{{match.meta.uri.title}}'
                     exec:
                       method: get
                       uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -9,6 +9,18 @@ spec: &spec
               user-agent: true
   title: The Change Propagation root
   paths:
+    /sys/limit:
+      x-modules:
+        - path: sys/rate_limiter.js
+          options:
+            redis:
+              host: localhost
+              port: 6379
+
+            limiters:
+              blacklist:
+                interval: 604800
+                limit: 100
     /sys/purge:
       x-modules:
         - path: sys/purge.js

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -180,6 +180,8 @@ spec: &spec
 
               page_edit:
                 topic: mediawiki.revision-create
+                limiters:
+                  blacklist: '{message.page_title}'
                 retry_on:
                   status:
                     - '5xx'
@@ -319,6 +321,8 @@ spec: &spec
                         schema_uri: 'resource_change/1'
                         uri: '/https?:\/\/[^\/]+\/wiki\/(?<title>.+)/'
                       tags: [ 'transcludes' ]
+                    limiters:
+                      blacklist: '{{match.meta.uri.title}}'
                     exec:
                       method: get
                       uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{{match.meta.uri.title}}'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -9,6 +9,17 @@ spec: &spec
               user-agent: true
   title: The Change Propagation root
   paths:
+    /sys/limit:
+      x-modules:
+        - path: sys/rate_limiter.js
+          options:
+            redis:
+              host: localhost
+              port: 6379
+            limiters:
+              blacklist:
+                interval: 604800
+                limit: 100
     /sys/queue:
       x-modules:
         - path: sys/kafka.js
@@ -39,6 +50,8 @@ spec: &spec
                   meta:
                     uri: '/sample/uri'
                   message: 'test'
+                limiters:
+                  blacklist: '{{message.message}}'
                 exec:
                   method: post
                   uri: 'http://mock.com'

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -50,6 +50,8 @@ class BaseExecutor {
         this._pendingMsgs = [];
         this._toCommit = undefined;
         this._consuming = false;
+
+        this._rateLimiters = Object.assign(this.options.limiters || {}, rule.spec.limiters || {});
     }
 
     subscribe() {
@@ -98,7 +100,12 @@ class BaseExecutor {
                 // Note: we don't return the promise here since we wanna process messages
                 // asynchronously from consuming them to be able to fill up the pendingMsg
                 // queue and achieve the level of concurrency we want.
-                this.processMessage(message, handler)
+                this._rateLimitMessage(message)
+                .then((isRateLimited) => {
+                    if (!isRateLimited) {
+                        return this.processMessage(message, handler);
+                    }
+                })
                 .finally(() => {
                     this._notifyFinished(msg);
                     if (this._pendingMsgs.length < this.concurrency && !this._consuming) {
@@ -128,6 +135,28 @@ class BaseExecutor {
             } else {
                 this._consuming = false;
             }
+        });
+    }
+
+    /**
+     * Checks whether a message should be rate-limited
+     * @param {Object} message the message to check
+     * @return {boolean}
+     * @private
+     */
+    _rateLimitMessage(message) {
+        return P.all(this.rule.getRateLimiterTypes().map((type) => {
+            const key = this.rule.getLimiterKey(type, message);
+            return this.hyper.get({
+                uri: `/sys/limit/${type}/${key}`
+            });
+        }))
+        .thenReturn(false)
+        // Will throw if any of the limiters failed,
+        // the error message will say which one is failed.
+        .catch({ status: 429 }, (e) => {
+            // TODO: log
+            return true;
         });
     }
 
@@ -332,14 +361,26 @@ class BaseExecutor {
         }
 
         if (!this.rule.shouldIgnoreError(e)) {
-            if (this.rule.shouldRetry(e)
-                && !this._isLimitExceeded(retryMessage, e)) {
+            if (this.rule.shouldRetry(e)) {
+                if (this._isLimitExceeded(retryMessage, e)) {
+                    const limiterKey = this.rule.getLimiterKey('blacklist', message);
+                    if (!limiterKey) {
+                        return reportError();
+                    }
+                    return this.hyper.post({
+                        uri: `/sys/limit/blacklist/${limiterKey}`
+                    })
+                    .catch({ status: 429 }, () => {
+                        // No need to react here, we'll reject the next message
+                    })
+                    .finally(reportError);
+                }
                 return this.hyper.post({
                     uri: '/sys/queue/events',
-                    body: [ retryMessage ]
-                });
+                    body: [retryMessage]
+                })
+                .then(reportError);
             }
-            return reportError();
         }
     }
 

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -100,12 +100,7 @@ class BaseExecutor {
                 // Note: we don't return the promise here since we wanna process messages
                 // asynchronously from consuming them to be able to fill up the pendingMsg
                 // queue and achieve the level of concurrency we want.
-                this._rateLimitMessage(message)
-                .then((isRateLimited) => {
-                    if (!isRateLimited) {
-                        return this.processMessage(message, handler);
-                    }
-                })
+                this.processMessage(message, handler)
                 .finally(() => {
                     this._notifyFinished(msg);
                     if (this._pendingMsgs.length < this.concurrency && !this._consuming) {
@@ -140,13 +135,13 @@ class BaseExecutor {
 
     /**
      * Checks whether a message should be rate-limited
-     * @param {Object} message the message to check
+     * @param {Object} expander the limiter key expander
      * @return {boolean}
      * @private
      */
-    _rateLimitMessage(message) {
+    _rateLimitMessage(expander) {
         return P.all(this.rule.getRateLimiterTypes().map((type) => {
-            const key = this.rule.getLimiterKey(type, message);
+            const key = this.rule.getLimiterKey(type, expander);
             return this.hyper.get({
                 uri: new URI(`/sys/limit/${type}/${key}`)
             });
@@ -164,7 +159,7 @@ class BaseExecutor {
                 rule_name: this.rule.name,
                 limiter: e.body.message,
                 limiter_key: e.body.key,
-                event_str: utils.stringify(message)
+                event_str: utils.stringify(expander.message)
             });
             // TODO: For now only log the rate-limited messages.
             return false;
@@ -252,9 +247,27 @@ class BaseExecutor {
         this.hyper.log('trace/sample', sampleLog);
     }
 
+    _updateLimiters(expander, status, time) {
+        return P.each(this.rule.getRateLimiterTypes(), (type) => {
+            // TODO: calculate the cost function!
+
+            if (status !== 200) {
+                const limiterKey = this.rule.getLimiterKey(type, expander);
+                return this.hyper.post({
+                    uri: new URI(`/sys/limit/${type}/${limiterKey}`)
+                }).catch({ status: 429 }, () => {
+                    // No need to react here, we'll reject the next message
+                }).catch({ status: 404 }, () => {
+                    // If the limiter module is not configured, ignore
+                });
+            }
+        });
+    }
+
     _exec(origEvent, handler, statDelayStartTime, retryEvent) {
         const rule = this.rule;
         const startTime = Date.now();
+
         const expander = {
             message: origEvent,
             match: handler.expand(origEvent)
@@ -276,32 +289,39 @@ class BaseExecutor {
         this.hyper.metrics.endTiming([`${this.statName}_delay`],
             statDelayStartTime || new Date(origEvent.meta.dt));
 
-        return P.each(handler.exec, (tpl) => {
-            const request = tpl.expand(expander);
-            request.headers = Object.assign(request.headers, {
-                'x-request-id': origEvent.meta.request_id,
-                'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
-            });
-            return this.hyper.request(request)
-            .tap((res) => {
-                if (res.status === 301) {
-                    // As we don't follow redirects, and we must always use normalized titles,
-                    // receiving 301 indicates some error. Log a warning.
-                    this.log(`warn/${this.rule.name}`, () => ({
-                        message: '301 redirect received, used a non-normalized title',
-                        rule: this.rule.name,
-                        event_str: utils.stringify(origEvent)
-                    }));
-                }
+        const redirectCheck = (res) => {
+            if (res.status === 301) {
+                // As we don't follow redirects, and we must use normalized titles,
+                // receiving 301 indicates some error. Log a warning.
+                this.log(`warn/${this.rule.name}`, () => ({
+                    message: '301 redirect received, used a non-normalized title',
+                    rule: this.rule.name,
+                    event_str: utils.stringify(origEvent)
+                }));
+            }
+        };
+
+        return this._rateLimitMessage(expander)
+        .then((isRateLimited) => {
+            if (isRateLimited) {
+                return { status: 200 };
+            }
+            return P.each(handler.exec, (tpl) => {
+                const request = tpl.expand(expander);
+                request.headers = Object.assign(request.headers, {
+                    'x-request-id': origEvent.meta.request_id,
+                    'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
+                });
+                return this.hyper.request(request)
+                    .tap(redirectCheck)
+                    .tap(this._sampleLog.bind(this, retryEvent || origEvent, request))
+                    .tapCatch(this._sampleLog.bind(this, retryEvent || origEvent, request));
             })
-            .tap(this._sampleLog.bind(this, retryEvent || origEvent, request))
-            .catch((e) => {
-                this._sampleLog(retryEvent || origEvent, request, e);
-                throw e;
+            .tap(() => this._updateLimiters(expander, 200, new Date() - startTime))
+            .tapCatch((e) => this._updateLimiters(expander, e.status, new Date() - startTime))
+            .finally(() => {
+                this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime);
             });
-        })
-        .finally(() => {
-            this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime);
         });
     }
 
@@ -379,26 +399,6 @@ class BaseExecutor {
                     body: [ retryMessage ]
                 });
             }
-
-            if (this._isLimitExceeded(retryMessage, e)) {
-                const limiterKey = this.rule.getLimiterKey('blacklist',
-                    retryMessage.original_event);
-
-                if (!limiterKey) {
-                    return reportError();
-                }
-                return this.hyper.post({
-                    uri: new URI(`/sys/limit/blacklist/${limiterKey}`)
-                })
-                .catch({ status: 429 }, () => {
-                    // No need to react here, we'll reject the next message
-                })
-                .catch({ status: 404 }, () => {
-                    // If the limiter module is not configured, ignore
-                })
-                .finally(reportError);
-            }
-
             return reportError();
         }
     }

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -313,9 +313,9 @@ class BaseExecutor {
                     'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
                 });
                 return this.hyper.request(request)
-                    .tap(redirectCheck)
-                    .tap(this._sampleLog.bind(this, retryEvent || origEvent, request))
-                    .tapCatch(this._sampleLog.bind(this, retryEvent || origEvent, request));
+                .tap(redirectCheck)
+                .tap(this._sampleLog.bind(this, retryEvent || origEvent, request))
+                .tapCatch(this._sampleLog.bind(this, retryEvent || origEvent, request));
             })
             .tap(() => this._updateLimiters(expander, 200, new Date() - startTime))
             .tapCatch(e => this._updateLimiters(expander, e.status, new Date() - startTime))

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -154,7 +154,7 @@ class BaseExecutor {
         // Will throw if any of the limiters failed,
         // the error message will say which one is failed.
         .catch({ status: 429 }, (e) => {
-            this.log('fatal/ratelimit', {
+            this.log('error/ratelimit', {
                 msg: 'Rate-limited message processing',
                 rule_name: this.rule.name,
                 limiter: e.body.message,
@@ -163,6 +163,23 @@ class BaseExecutor {
             });
             // TODO: For now only log the rate-limited messages.
             return false;
+        });
+    }
+
+    _updateLimiters(expander, status, time) {
+        return P.each(this.rule.getRateLimiterTypes(), (type) => {
+            // TODO: calculate the cost function and actually POST the cost!
+
+            if (status >= 500) {
+                const limiterKey = this.rule.getLimiterKey(type, expander);
+                return this.hyper.post({
+                    uri: new URI(`/sys/limit/${type}/${limiterKey}`)
+                }).catch({ status: 429 }, () => {
+                    // No need to react here, we'll reject the next message
+                }).catch({ status: 404 }, () => {
+                    // If the limiter module is not configured, ignore
+                });
+            }
         });
     }
 
@@ -247,23 +264,6 @@ class BaseExecutor {
         this.hyper.log('trace/sample', sampleLog);
     }
 
-    _updateLimiters(expander, status, time) {
-        return P.each(this.rule.getRateLimiterTypes(), (type) => {
-            // TODO: calculate the cost function!
-
-            if (status !== 200) {
-                const limiterKey = this.rule.getLimiterKey(type, expander);
-                return this.hyper.post({
-                    uri: new URI(`/sys/limit/${type}/${limiterKey}`)
-                }).catch({ status: 429 }, () => {
-                    // No need to react here, we'll reject the next message
-                }).catch({ status: 404 }, () => {
-                    // If the limiter module is not configured, ignore
-                });
-            }
-        });
-    }
-
     _exec(origEvent, handler, statDelayStartTime, retryEvent) {
         const rule = this.rule;
         const startTime = Date.now();
@@ -318,10 +318,8 @@ class BaseExecutor {
                     .tapCatch(this._sampleLog.bind(this, retryEvent || origEvent, request));
             })
             .tap(() => this._updateLimiters(expander, 200, new Date() - startTime))
-            .tapCatch((e) => this._updateLimiters(expander, e.status, new Date() - startTime))
-            .finally(() => {
-                this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime);
-            });
+            .tapCatch(e => this._updateLimiters(expander, e.status, new Date() - startTime))
+            .finally(() => this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime));
         });
     }
 

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -3,6 +3,7 @@
 const P = require('bluebird');
 const uuid = require('cassandra-uuid').TimeUuid;
 const HTTPError = require('hyperswitch').HTTPError;
+const URI = require('hyperswitch').URI;
 const kafka = require('node-rdkafka');
 
 const utils = require('./utils');
@@ -50,8 +51,6 @@ class BaseExecutor {
         this._pendingMsgs = [];
         this._toCommit = undefined;
         this._consuming = false;
-
-        this._rateLimiters = Object.assign(this.options.limiters || {}, rule.spec.limiters || {});
     }
 
     subscribe() {
@@ -73,7 +72,7 @@ class BaseExecutor {
         } catch (e) {
             this.log(`error/${this.rule.name}`, e);
             this.hyper.post({
-                uri: '/sys/queue/events',
+                uri: new URI('/sys/queue/events'),
                 body: [ this._constructErrorMessage(e, payload) ]
             });
         }
@@ -92,6 +91,7 @@ class BaseExecutor {
 
             const msg = messages[0];
             const message = this._safeParse(msg.value.toString('utf8'));
+
             const handler = this.getHandler(message);
             if (handler) {
                 // We're pushing it to pending messages only if it matched so that items
@@ -148,15 +148,26 @@ class BaseExecutor {
         return P.all(this.rule.getRateLimiterTypes().map((type) => {
             const key = this.rule.getLimiterKey(type, message);
             return this.hyper.get({
-                uri: `/sys/limit/${type}/${key}`
+                uri: new URI(`/sys/limit/${type}/${key}`)
             });
         }))
         .thenReturn(false)
+        .catch({ status: 404 }, () => {
+            // If the limiter module is not configured, ignore
+            return false;
+        })
         // Will throw if any of the limiters failed,
         // the error message will say which one is failed.
         .catch({ status: 429 }, (e) => {
-            // TODO: log
-            return true;
+            this.log('fatal/ratelimit', {
+                msg: 'Rate-limited message processing',
+                rule_name: this.rule.name,
+                limiter: e.body.message,
+                limiter_key: e.body.key,
+                event_str: utils.stringify(message)
+            });
+            // TODO: For now only log the rate-limited messages.
+            return false;
         });
     }
 
@@ -234,7 +245,7 @@ class BaseExecutor {
             };
             // Don't include the full body in the log
             if (res.status >= 400) {
-                sampleLog.response.body = BaseExecutor.decodeError(res).body;
+                log.response.body = BaseExecutor.decodeError(res).body;
             }
             return log;
         };
@@ -344,7 +355,7 @@ class BaseExecutor {
 
     _catch(message, retryMessage, e) {
         const reportError = () => this.hyper.post({
-            uri: '/sys/queue/events',
+            uri: new URI('/sys/queue/events'),
             body: [this._constructErrorMessage(e, message)]
         });
 
@@ -361,26 +372,34 @@ class BaseExecutor {
         }
 
         if (!this.rule.shouldIgnoreError(e)) {
-            if (this.rule.shouldRetry(e)) {
-                if (this._isLimitExceeded(retryMessage, e)) {
-                    const limiterKey = this.rule.getLimiterKey('blacklist', message);
-                    if (!limiterKey) {
-                        return reportError();
-                    }
-                    return this.hyper.post({
-                        uri: `/sys/limit/blacklist/${limiterKey}`
-                    })
-                    .catch({ status: 429 }, () => {
-                        // No need to react here, we'll reject the next message
-                    })
-                    .finally(reportError);
+            if (this.rule.shouldRetry(e)
+                && !this._isLimitExceeded(retryMessage, e)) {
+                return this.hyper.post({
+                    uri: new URI('/sys/queue/events'),
+                    body: [ retryMessage ]
+                });
+            }
+
+            if (this._isLimitExceeded(retryMessage, e)) {
+                const limiterKey = this.rule.getLimiterKey('blacklist',
+                    retryMessage.original_event);
+
+                if (!limiterKey) {
+                    return reportError();
                 }
                 return this.hyper.post({
-                    uri: '/sys/queue/events',
-                    body: [retryMessage]
+                    uri: new URI(`/sys/limit/blacklist/${limiterKey}`)
                 })
-                .then(reportError);
+                .catch({ status: 429 }, () => {
+                    // No need to react here, we'll reject the next message
+                })
+                .catch({ status: 404 }, () => {
+                    // If the limiter module is not configured, ignore
+                })
+                .finally(reportError);
             }
+
+            return reportError();
         }
     }
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -163,6 +163,13 @@ class Rule {
         this.shouldRetry = _compileErrorCheckCondition(this.spec.retry_on);
         this.shouldIgnoreError = _compileErrorCheckCondition(this.spec.ignore);
 
+        this._limiterKeyTemplates = {};
+        if (this.spec.limiters) {
+            Object.keys(this.spec.limiters).forEach((type) => {
+                this._limiterKeyTemplates[type] = new Template(this.spec.limiters[type]);
+            });
+        }
+
         this._options = (this.spec.cases || [ this.spec ]).map((option) => {
             const matcher = this._processMatch(option.match) || {};
             const result = {
@@ -227,6 +234,24 @@ class Rule {
                 return option.expand && option.expand(message) || {};
             }
         };
+    }
+
+    /**
+     * Returns the key to use for a rate-limiter of the certain type
+     * @param {string} type limiter type
+     * @param {Object} message the event to limit
+     * @return {string|null}
+     */
+    getLimiterKey(type, message) {
+        const keyTemplate = this._limiterKeyTemplates[type];
+        if (!keyTemplate) {
+            return null;
+        }
+        return keyTemplate.expand({ message });
+    }
+
+    getRateLimiterTypes() {
+        return Object.keys(this._limiterKeyTemplates);
     }
 
     _processMatch(match) {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -166,7 +166,11 @@ class Rule {
         this._limiterKeyTemplates = {};
         if (this.spec.limiters) {
             Object.keys(this.spec.limiters).forEach((type) => {
-                this._limiterKeyTemplates[type] = new Template(this.spec.limiters[type]);
+                try {
+                    this._limiterKeyTemplates[type] = new Template(this.spec.limiters[type]);
+                } catch (e) {
+                    throw new Error(`Compilation failed for limiter ${type}. Error: ${e.message}`);
+                }
             });
         }
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -6,9 +6,9 @@ const HyperSwitch = require('hyperswitch');
 const Sampler = require('./sampler');
 const Template = HyperSwitch.Template;
 
-const DEFAULT_RETRY_DELAY = 1;  // One minute minimum retry delay
-const DEFAULT_RETRY_FACTOR = 1;     // Exponential back-off
-const DEFAULT_RETRY_LIMIT = 0;      // At most two retries
+const DEFAULT_RETRY_DELAY = 60000;  // One minute minimum retry delay
+const DEFAULT_RETRY_FACTOR = 6;     // Exponential back-off
+const DEFAULT_RETRY_LIMIT = 2;      // At most two retries
 // Set a larger request timeout then RESTBase default 6 minutes;
 const DEFAULT_REQUEST_TIMEOUT = 7 * 60 * 1000;
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -239,15 +239,19 @@ class Rule {
     /**
      * Returns the key to use for a rate-limiter of the certain type
      * @param {string} type limiter type
-     * @param {Object} message the event to limit
+     * @param {Object} expander the expander containing the message and match
      * @return {string|null}
      */
-    getLimiterKey(type, message) {
+    getLimiterKey(type, expander) {
+        try {
         const keyTemplate = this._limiterKeyTemplates[type];
         if (!keyTemplate) {
             return null;
         }
-        return keyTemplate.expand({ message });
+        return keyTemplate.expand(expander);
+        } catch (e) {
+            console.log(e, expander);
+        }
     }
 
     getRateLimiterTypes() {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -243,15 +243,11 @@ class Rule {
      * @return {string|null}
      */
     getLimiterKey(type, expander) {
-        try {
         const keyTemplate = this._limiterKeyTemplates[type];
         if (!keyTemplate) {
             return null;
         }
         return keyTemplate.expand(expander);
-        } catch (e) {
-            console.log(e, expander);
-        }
     }
 
     getRateLimiterTypes() {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -6,9 +6,9 @@ const HyperSwitch = require('hyperswitch');
 const Sampler = require('./sampler');
 const Template = HyperSwitch.Template;
 
-const DEFAULT_RETRY_DELAY = 60000;  // One minute minimum retry delay
-const DEFAULT_RETRY_FACTOR = 6;     // Exponential back-off
-const DEFAULT_RETRY_LIMIT = 2;      // At most two retries
+const DEFAULT_RETRY_DELAY = 1;  // One minute minimum retry delay
+const DEFAULT_RETRY_FACTOR = 1;     // Exponential back-off
+const DEFAULT_RETRY_LIMIT = 0;      // At most two retries
 // Set a larger request timeout then RESTBase default 6 minutes;
 const DEFAULT_REQUEST_TIMEOUT = 7 * 60 * 1000;
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "mediawiki-title": "^0.5.6",
     "murmur-32": "^0.1.0",
     "node-rdkafka": "^1.0.0",
-    "node-rdkafka-statsd": "^0.1.0"
+    "node-rdkafka-statsd": "^0.1.0",
+    "ratelimit.js": "^1.8.0",
+    "redis": "^2.7.1"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/sys/rate_limiter.js
+++ b/sys/rate_limiter.js
@@ -12,6 +12,10 @@ class RateLimiter {
         this._log = this._options.log || (() => {});
 
         // TODO: verify and pass in the redis options
+
+        this._options.redis = Object.assign(this._options.redis, {
+            no_ready_check: true // Prevents sending unsupported info command to nutcracker
+        });
         this._client = redis.createClient(this._options.redis);
         HyperSwitch.lifecycle.on('close', () => this._client.quit());
 

--- a/sys/rate_limiter.js
+++ b/sys/rate_limiter.js
@@ -12,6 +12,7 @@ class RateLimiter {
 
         // TODO: verify and pass in the redis options
         this._client = redis.createClient(this._options.redis);
+        HyperSwitch.lifecycle.on('close', () => this._client.quit());
 
         // TODO: configurable options
 

--- a/sys/rate_limiter.js
+++ b/sys/rate_limiter.js
@@ -3,7 +3,8 @@
 const Limiter = require('ratelimit.js').RateLimit;
 const redis = require('redis');
 const P = require('bluebird');
-const HTTPError = require('hyperswitch').HTTPError;
+const HyperSwitch = require('hyperswitch');
+const HTTPError = HyperSwitch.HTTPError;
 
 class RateLimiter {
     constructor(options) {

--- a/sys/rate_limiter.js
+++ b/sys/rate_limiter.js
@@ -1,0 +1,86 @@
+"use strict";
+
+const Limiter = require('ratelimit.js').RateLimit;
+const redis = require('redis');
+const P = require('bluebird');
+const HTTPError = require('hyperswitch').HTTPError;
+
+class RateLimiter {
+    constructor(options) {
+        this._options = options;
+        this._log = this._options.log || (() => {});
+
+        // TODO: verify and pass in the redis options
+        this._client = redis.createClient(this._options.redis);
+
+        // TODO: configurable options
+
+        this._LIMITERS = new Map();
+        Object.keys(this._options.limiters).forEach((type) => {
+            const limiterOpts = this._options.limiters[type];
+            this._LIMITERS.set(type, new Limiter(this._client, [
+                limiterOpts
+            ], { prefix: `CPLimiter_${type}` }));
+        });
+    }
+
+    _execLimiterFun(fun, hyper, type, key) {
+        const limiter = this._LIMITERS.get(type);
+        if (!limiter) {
+            return { status: 204 };
+        }
+
+        return new P((resolve, reject) => {
+            limiter[fun](key, (err, isRateLimited) => {
+                if (err) {
+                    // TODO: log!
+                    // In case we've got problems with limiting just allow everything
+                    return resolve({ status: 200 });
+                }
+
+                if (isRateLimited) {
+                    return reject(new HTTPError({
+                        status: 429,
+                        body: {
+                            type: 'rate_limit',
+                            message: `Message rejected by limiter ${type}`,
+                            key
+                        }
+                    }));
+                }
+                return resolve({ status: 201 });
+            });
+        });
+    }
+
+    increment(hyper, req) {
+        return this._execLimiterFun('incr', hyper, req.params.type, req.params.key);
+    }
+
+    check(hyper, req) {
+        return this._execLimiterFun('check', hyper, req.params.type, req.params.key);
+    }
+}
+
+module.exports = (options) => {
+    const ps = new RateLimiter(options);
+
+    return {
+        spec: {
+            paths: {
+                '/{type}/{key}': {
+                    post: {
+                        operationId: 'incrementAndCheck'
+                    },
+                    get: {
+                        operationId: 'check'
+                    }
+                }
+            }
+        },
+        operations: {
+            incrementAndCheck: ps.increment.bind(ps),
+            check: ps.check.bind(ps)
+        }
+    };
+};


### PR DESCRIPTION
Basically, there will be a limiter module. In it's config you can specify limiters with arbitrary names, for example `blacklist`. Then in each rule you can add `limiters` stanza to specify a template of the key that would be used in a particular limiter. The limiter names will be predefined, because the limiter counters needs to be updated under different circumstances. For example for the `blacklist` limiter we have to bump the counter in case of a 503 and retry limit is exceeded, while for `rerender_rate` limiter we have to bump the counter on every successful rerender of a certain revision. I'm not quite sure how to generalize it even more and whether we need to generalize it more..

cc @wikimedia/services 