### PR TITLE
Added ability to run executor steps in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ rules to workers equally.
 
 The rule can contain the following properties:
 - **topic** A name of the topic to subscribe to.
+- **parallel** Whether to run the executor steps sequentially or in parallel. Default: `false` 
 - **match** An optional predicate for a message. The rule is executed only if all of the `match`
 properties were satisfied by the message. Properties could be nested objects, constants
 or a regex. Regex could contain capture groups and captured values will later be accessible

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -328,6 +328,7 @@ spec: &spec
               ores_cache:
                 topic: mediawiki.revision-create
                 concurrency: 10
+                parallel: true
                 ignore:
                   status:
                     - 503

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -235,7 +235,7 @@ class BaseExecutor {
         this.hyper.metrics.endTiming([`${this.statName}_delay`],
             statDelayStartTime || new Date(origEvent.meta.dt));
 
-        return P.each(handler.exec, (tpl) => {
+        const executeTemplate = (tpl) => {
             const request = tpl.expand(expander);
             request.headers = Object.assign(request.headers, {
                 'x-request-id': origEvent.meta.request_id,
@@ -258,8 +258,15 @@ class BaseExecutor {
                 this._sampleLog(retryEvent || origEvent, request, e);
                 throw e;
             });
-        })
-        .finally(() => {
+        };
+
+        let action;
+        if (this.rule.spec.parallel) {
+            action = P.all(handler.exec.map(executeTemplate));
+        } else {
+            action = P.each(handler.exec, executeTemplate);
+        }
+        return action.finally(() => {
             this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime);
         });
     }


### PR DESCRIPTION
For ORES it doesn't make sense to run the reqs to both Das sequentially, so support doing parallel requests. 

I guess at some point we might wanna bring in the full-blown tempting support from hyper switch here, but for now this simple change is enough.

cc @wikimedia/services 