### PR TITLE
Sampler: Bug Fix: Return a Promise instead of an Object

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -224,7 +224,7 @@ class BaseExecutor {
                 msg: 'Disregarding event; Filtered by sampler',
                 event: utils.stringify(origEvent)
             }));
-            return { status: 200 };
+            return P.resolve({ status: 200 });
         }
 
         this.log(`trace/${rule.name}`, () => ({


### PR DESCRIPTION
Change Propagation's rule execution mechanism expects a Promise to be
returned when executing a rule. Alas, if the sampler is active, only an
Object is being returned. This commit fixes the obvious error.

This is a follow-up on PR #166