### PR TITLE
Bug Fix: Test mode: Remove the processed message from the queue

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -132,12 +132,13 @@ class BaseExecutor {
     }
 
     _notifyFinished(finishedMsg) {
+        this._pendingMsgs = this._pendingMsgs.filter(o => o.offset !== finishedMsg.offset);
+
         if (this.options.test_mode) {
             this.log('trace/commit', 'Running in TEST MODE; Offset commits disabled');
             return;
         }
 
-        this._pendingMsgs = this._pendingMsgs.filter(o => o.offset !== finishedMsg.offset);
         if (this._pendingMsgs.length) {
             this._toCommit = this._pendingMsgs.sort((msg1, msg2) => {
                 return msg1.offset - msg2.offset;


### PR DESCRIPTION
Regardless of whether we are going to actually commit the offset or not,
if a message has been processed it needs to be removed from the list of
pending messages, as otherwise a deadlock occurs because Change
Propagation will not process new messages while the length of that array
is greater than the allowed concurrency.

This is another follow-up on #166 