### PR TITLE
Limit errors per hour as well as per week

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -19,8 +19,15 @@ spec: &spec
 
             limiters:
               blacklist:
-                interval: 604800
-                limit: 100
+                # First, allow no more then 100 errors per week
+                # The precision parameter controls the step a sliding window moves by
+                - interval: 604800
+                  limit: 100
+                  precision: 86400
+                # Secondly to avoid bursts in case of outages, don't allow more then 10
+                # errors per hour
+                - interval: 3600
+                  limit: 10
     /sys/purge:
       x-modules:
         - path: sys/purge.js

--- a/sys/rate_limiter.js
+++ b/sys/rate_limiter.js
@@ -33,15 +33,20 @@ class RateLimiter {
 
         this._LIMITERS = new Map();
         Object.keys(this._options.limiters).forEach((type) => {
-            const limiterOpts = this._options.limiters[type];
+            let limiterOpts = this._options.limiters[type];
 
-            if (!limiterOpts.interval || !limiterOpts.limit) {
-                throw new Error(`Limiter ${type} is miconfigured`);
+            if (!Array.isArray(limiterOpts)) {
+                limiterOpts = [ limiterOpts ];
             }
 
-            this._LIMITERS.set(type, new Limiter(this._client, [
-                limiterOpts
-            ], { prefix: `CPLimiter_${type}` }));
+            limiterOpts.forEach((opt) => {
+                if (!opt.interval || !opt.limit) {
+                    throw new Error(`Limiter ${type} is miconfigured`);
+                }
+            });
+
+            this._LIMITERS.set(type, new Limiter(this._client, limiterOpts,
+                { prefix: `CPLimiter_${type}` }));
         });
     }
 


### PR DESCRIPTION
Two things are happening here:
1. We add the 'precision' property to the weekly limiter. We're using the sliding window limiter, and precision is controlling the step which the window is moving by. So, if we have a steady error rate, without the precision we will have 100 errors in the beginning on the window, then 1 week of silence, and then the window moves and we have 100 more errors. With 1-day step we will allow the page back each day to probe if the error has gone.
2. We add a second, shorter-term limiter to allow only 10 errors per hour. If there's an outage and a burst of errors, we will only reach 10 errors, not using all the allowed errors for the whole week. After an hour, we will probe again and if the outage is gone we've only used up 10 out of allowed 100 errors. If the page is generally not parseable, after 10 hours we will exceed the weekly limit and block it for the whole week. This is needed because right now some of the legit pages are being blocked for a week because they've happened to have lots of activity in the unlucky timing of Cassandra OOM.

We can play with the exact numbers for precision, limit interval and limit value, but decreasing the precision or interval comes with a cost on Redis. Since it's still only logging, I think the values I choose are reasonable enough to give them a try.

cc @wikimedia/services 