### PR TITLE
Start actually rate-limiting

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -161,8 +161,7 @@ class BaseExecutor {
                 limiter_key: e.body.key,
                 event_str: utils.stringify(expander.message)
             });
-            // TODO: For now only log the rate-limited messages.
-            return false;
+            return true;
         });
     }
 


### PR DESCRIPTION
I've been analyzing the just-logging rate limiter results and everything it blocks seems legit. Also after we've introduced a short-term limiter, short issues in Cassandra or short parsed outages doesn't have long-term consequences.

Maybe we could fine-tune it to block some more pages, but it definitely won't harm to start actually blocking. 

cc @wikimedia/services 