### PR TITLE
Only update when the content of the revision actually changed

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -193,17 +193,19 @@ spec: &spec
                   status:
                     - '5xx'
                     - 404 # Sometimes occasional 404s happen because of the mysql replication lag, so retry
+                match:
+                  rev_content_changed: true
+                match_not:
                 # Test-only. We use undefined rev_parent_id to test backlinks so we
                 # don't want transclusions to interfere with backlinks test
-                match_not:
                   - rev_parent_id: undefined
+                # end of test-only config
                   - meta:
                       domain: /\.wikidata\.org$/
                     page_namespace: 0
                   - meta:
                       domain: /\.wikidata\.org$/
                     page_namespace: 120
-                # end of test-only config
                 exec:
                   - method: get
                     uri: 'https://{{message.meta.domain}}/api/rest_v1/page/html/{message.page_title}/{{message.rev_id}}'
@@ -586,6 +588,7 @@ spec: &spec
                   # It's impossible to modify a comment in wikidata while editing the entity.
                   # TODO: This is a temp solution until we get a more general fragment support T148079
                   comment: '/wbeditentity|wbsetdescription|undo/'
+                  rev_content_changed: true
                 exec:
                   method: post
                   uri: '/sys/links/wikidata_descriptions'

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -294,7 +294,8 @@ describe('RESTBase update rules', function() {
                 page_title: 'User:Pchelolo/Test',
                 rev_id: 1234,
                 rev_timestamp: new Date().toISOString(),
-                rev_parent_id: 1233
+                rev_parent_id: 1233,
+                rev_content_changed: true
             }))))
         .then(() => common.checkAPIDone(mwAPI))
         .finally(() => nock.cleanAll());
@@ -322,7 +323,8 @@ describe('RESTBase update rules', function() {
                 rev_id: 1234,
                 rev_timestamp: new Date().toISOString(),
                 rev_parent_id: 1233,
-                page_namespace: 0
+                page_namespace: 0,
+                rev_content_changed: true
             }))))
         .then(() => common.checkPendingMocks(mwAPI, 1))
         .finally(() => nock.cleanAll());
@@ -545,7 +547,8 @@ describe('RESTBase update rules', function() {
                 },
                 page_title: 'Q1',
                 page_namespace: 0,
-                comment: "/* wbeditentity-update:0| */ add [it] label"
+                comment: "/* wbeditentity-update:0| */ add [it] label",
+                rev_content_changed: true
             }))))
         .delay(common.REQUEST_CHECK_DELAY)
         .then(() => common.checkAPIDone(wikidataAPI))
@@ -609,7 +612,8 @@ describe('RESTBase update rules', function() {
                 },
                 page_title: 'Q1',
                 page_namespace: 0,
-                comment: "/* undo */ Undo revision 440223057 by Mhollo"
+                comment: "/* undo */ Undo revision 440223057 by Mhollo",
+                rev_content_changed: true
             }))))
         .delay(common.REQUEST_CHECK_DELAY)
         .then(() => common.checkAPIDone(wikidataAPI))
@@ -716,7 +720,8 @@ describe('RESTBase update rules', function() {
                     domain: 'www.wikidata.org'
                 },
                 page_title: 'Property:P1',
-                page_namespace: 3
+                page_namespace: 3,
+                rev_content_changed: true
             }))))
         .delay(common.REQUEST_CHECK_DELAY)
         .then(() => common.checkPendingMocks(wikidataAPI, 1))
@@ -756,7 +761,8 @@ describe('RESTBase update rules', function() {
                 },
                 page_title: 'Q2',
                 page_namespace: 0,
-                comment: "/* wbeditentity-update:0| */ add [it] label"
+                comment: "/* wbeditentity-update:0| */ add [it] label",
+                rev_content_changed: true
             }))))
         .delay(common.REQUEST_CHECK_DELAY)
         .then(() => common.checkAPIDone(wikidataAPI))
@@ -828,7 +834,8 @@ describe('RESTBase update rules', function() {
                 },
                 page_title: 'File:Pchelolo/Test.jpg',
                 rev_parent_id: 12345, // Needed to avoid backlinks updates firing and interfering
-                rev_id: 112233
+                rev_id: 112233,
+                rev_content_changed: true
             }))))
         .then(() => common.checkAPIDone(mwAPI, 50))
         .finally(() => nock.cleanAll());
@@ -911,7 +918,8 @@ describe('RESTBase update rules', function() {
                 },
                 page_title: 'Test_Page',
                 rev_parent_id: 12345, // Needed to avoid backlinks updates firing and interfering
-                rev_id: 112233
+                rev_id: 112233,
+                rev_content_changed: true
             }))))
         .then(() => common.checkAPIDone(mwAPI, 50))
         .finally(() => nock.cleanAll());


### PR DESCRIPTION
Some actions on the wiki, like page protection changes, can create a new revision without actually changing the page contents. Obviously, It doesn't make sense to rerender a page if it's content hasn't changed.

cc @wikimedia/services 