### PR TITLE
Make a generic redis-based deduplicator

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -13,7 +13,7 @@ spec: &spec
       x-modules:
         - path: sys/rate_limiter.js
           options:
-            redis:
+            redis: &redis_config
               host: localhost
               port: 6379
 
@@ -28,6 +28,11 @@ spec: &spec
                 # errors per hour
                 - interval: 3600
                   limit: 10
+    /sys/dedupe:
+      x-modules:
+        - path: sys/deduplicator.js
+          options:
+            redis: *redis_config
     /sys/purge:
       x-modules:
         - path: sys/purge.js

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -305,7 +305,8 @@ class BaseExecutor {
             if (isRateLimited) {
                 return { status: 200 };
             }
-            return P.each(handler.exec, (tpl) => {
+            return this._dedupeMessage(expander)
+            .then(() => P.each(handler.exec, (tpl) => {
                 const request = tpl.expand(expander);
                 request.headers = Object.assign(request.headers, {
                     'x-request-id': origEvent.meta.request_id,
@@ -318,8 +319,25 @@ class BaseExecutor {
             })
             .tap(() => this._updateLimiters(expander, 200, new Date() - startTime))
             .tapCatch(e => this._updateLimiters(expander, e.status, new Date() - startTime))
-            .finally(() => this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime));
+            .finally(() => this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime)));
         });
+    }
+
+    _dedupeMessage(expander) {
+        return this.hyper.post({
+            uri: new URI(`/sys/dedupe/${this.rule.name}`),
+            body: expander.message
+        })
+        .then((result) => {
+            if (result.body) {
+                this.log('warn/dedupe', {
+                    message: 'Event was deduplicated',
+                    event_str: utils.stringify(expander.message)
+                });
+            }
+        })
+        .catch({ status: 404 }, () => {})
+        .thenReturn(expander);
     }
 
     _retryTopicName() {

--- a/lib/mixins.js
+++ b/lib/mixins.js
@@ -35,8 +35,9 @@ class MixinBuilder {
         this.superclass = superclass;
     }
 
-    with(...mixins) {
-        return mixins.reduce((c, mixin) => mixin(c), this.superclass);
+    with() {
+        return Array.prototype.slice.call(arguments)
+        .reduce((c, mixin) => mixin(c), this.superclass);
     }
 }
 

--- a/lib/mixins.js
+++ b/lib/mixins.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const P = require('bluebird');
+const redis = require('redis');
+const HyperSwitch = require('hyperswitch');
+
+const Redis = superclass => class extends superclass {
+    constructor(options) {
+        super(options);
+
+        if (!options.redis) {
+            throw new Error('Redis options not provided to the rate_limiter');
+        }
+
+        if (!(options.redis.host && options.redis.port)
+            && !options.redis.path) {
+            throw new Error('Redis host:port or unix socket path must be specified');
+        }
+
+        options.redis = Object.assign(options.redis, {
+            no_ready_check: true // Prevents sending unsupported info command to nutcracker
+        });
+        this._redis = P.promisifyAll(redis.createClient(options.redis));
+        this._redis.on('error', (e) => {
+            // If we can't connect to redis - don't worry and don't fail,
+            // just log it and ignore.
+            options.log('error/redis', e);
+        });
+        HyperSwitch.lifecycle.on('close', () => this._redis.quit());
+    }
+};
+
+class MixinBuilder {
+    constructor(superclass) {
+        this.superclass = superclass;
+    }
+
+    with(...mixins) {
+        return mixins.reduce((c, mixin) => mixin(c), this.superclass);
+    }
+}
+
+module.exports = {
+    mix: superclass => new MixinBuilder(superclass),
+    Redis
+};

--- a/lib/mixins.js
+++ b/lib/mixins.js
@@ -6,7 +6,12 @@ const HyperSwitch = require('hyperswitch');
 
 const Redis = superclass => class extends superclass {
     constructor(options) {
-        super(options);
+        if (superclass !== Object) {
+            super(options);
+        } else {
+            // Don't need to pass the options to the Object super constructor.
+            super();
+        }
 
         if (!options.redis) {
             throw new Error('Redis options not provided to the rate_limiter');

--- a/sys/deduplicator.js
+++ b/sys/deduplicator.js
@@ -30,7 +30,7 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
         // Expire the key or renew the expiration timestamp if the key existed
         .tap(() => this._redis.expireAsync(messageKey, this._expire_timeout))
         // If that key already existed - that means it's a duplicate
-        .then((setResult) => setResult ? NOT_DUPLICATE : DUPLICATE)
+        .then((setResult) => { return setResult ? NOT_DUPLICATE : DUPLICATE; })
         .then((individualDeduplicated) => {
             if (individualDeduplicated.body || !message.root_event) {
                 // If the message was individually deduped or if it has no root event info,

--- a/sys/deduplicator.js
+++ b/sys/deduplicator.js
@@ -1,0 +1,84 @@
+"use strict";
+
+const mixins = require('../lib/mixins');
+
+const DUPLICATE = { status: 200, body: true };
+const NOT_DUPLICATE = { status: 200, body: false };
+
+class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
+    constructor(options) {
+        super(options);
+
+        this._options = options;
+        this._log = this._options.log || (() => {});
+        this._expire_timeout = options.window || 86400;
+    }
+
+    /**
+     * Checks whether the message is a duplicate
+     * @param {HyperSwitch} hyper
+     * @param {Object} req
+     * @return {Promise} response status shows whether it's a duplicate or not.
+     */
+    checkDuplicate(hyper, req) {
+        const name = req.params.name;
+        const message = req.body;
+
+        // First, look at the individual event duplication
+        const messageKey = `CP_dedupe_${name}_${message.meta.id}`;
+        return this._redis.setnxAsync(`CP_dedupe_${name}_${message.meta.id}`, '1')
+        .then((setResult) => {
+            if (!setResult) {
+                // If that key already existed - that means it's a duplicate
+                return DUPLICATE;
+            }
+            return this._redis.expireAsync(messageKey, this._expire_timeout)
+            .thenReturn(NOT_DUPLICATE);
+        })
+        .then((individualDeduplicated) => {
+            if (individualDeduplicated.body || !message.root_event) {
+                // If the message was individually deduped or if it has no root event info,
+                // don't use deduplication by the root event
+                return individualDeduplicated;
+            }
+
+            const rootEventKey = `CP_dedupe_${name}_${message.root_event.signature}`;
+            return this._redis.getAsync(rootEventKey)
+            .then((oldEventTimestamp) => {
+                if (oldEventTimestamp
+                        && new Date(oldEventTimestamp) > new Date(message.root_event.dt)) {
+                    return DUPLICATE;
+                }
+                return this._redis.setAsync(rootEventKey, message.root_event.dt)
+                .then(() => this._redis.expireAsync(rootEventKey, this._expire_timeout))
+                .thenReturn(NOT_DUPLICATE);
+            });
+        })
+        .catch((e) => {
+            this._log('error/dedupe', {
+                message: 'Error during deduplication',
+                error: e
+            });
+            return NOT_DUPLICATE;
+        });
+    }
+}
+
+module.exports = (options) => {
+    const ps = new Deduplicator(options);
+
+    return {
+        spec: {
+            paths: {
+                '/{name}': {
+                    post: {
+                        operationId: 'checkDuplicate'
+                    }
+                }
+            }
+        },
+        operations: {
+            checkDuplicate: ps.checkDuplicate.bind(ps)
+        }
+    };
+};

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -6,8 +6,6 @@ const Template = HyperSwitch.Template;
 const utils = require('../lib/utils');
 const Title = require('mediawiki-title').Title;
 
-const DEDUPE_LOG_SIZE = 100;
-
 function createBackLinksTemplate(options) {
     return {
         template: new Template(extend(true, {}, options.templates.mw_api, {
@@ -116,6 +114,56 @@ function createWikidataTemplate(options) {
     };
 }
 
+function _sendContinueEvent(hyper, topic, origEvent, continueToken) {
+    return hyper.post({
+        uri: '/sys/queue/events',
+        body: [{
+            meta: {
+                topic,
+                schema_uri: 'continue/1',
+                uri: origEvent.meta.uri,
+                request_id: origEvent.meta.request_id,
+                domain: origEvent.meta.domain,
+                dt: origEvent.meta.dt
+            },
+            triggered_by: utils.triggeredBy(origEvent),
+            root_event: {
+                signature: origEvent.meta.uri,
+                dt: origEvent.meta.dt
+            },
+            original_event: origEvent,
+            continue: continueToken,
+        }]
+    });
+}
+
+function _sendResourceChanges(hyper, items, originalEvent, tags, topicName) {
+    return hyper.post({
+        uri: '/sys/queue/events',
+        body: items.map((item) => {
+            // TODO: need to check whether a wiki is http or https!
+            const resourceURI =
+                `https://${item.domain}/wiki/${encodeURIComponent(item.title)}`;
+            return {
+                meta: {
+                    topic: topicName,
+                    schema_uri: 'resource_change/1',
+                    uri: resourceURI,
+                    request_id: originalEvent.meta.request_id,
+                    domain: item.domain,
+                    dt: originalEvent.meta.dt
+                },
+                triggered_by: utils.triggeredBy(originalEvent),
+                tags,
+                root_event: {
+                    signature: originalEvent.meta.uri,
+                    dt: originalEvent.meta.dt
+                }
+            };
+        })
+    });
+}
+
 class DependencyProcessor {
     constructor(options) {
         this.options = options;
@@ -150,45 +198,6 @@ class DependencyProcessor {
         });
     }
 
-    _isDuplicate(message) {
-        if (!message.continue) {
-            // Not a continuation event, don't deduplicate
-            return false;
-        }
-
-        const currEventInfo = {
-            domain: message.meta.domain,
-            title: message.original_event.page_title,
-            id: message.original_event.meta.id,
-            sequence_num: message.sequence_num
-        };
-
-        // Don't know the seq_num, probably old event, can't deduplicate
-        if (currEventInfo.sequence_num === undefined) {
-            return false;
-        }
-
-        if (this.latestMessages.some((oldEvent) => {
-            return oldEvent.domain === currEventInfo.domain
-                    && oldEvent.title === currEventInfo.title
-                        // This represents forking - we've consumed some continuation twice,
-                        // so we've got exact same event processed recently
-                    && (oldEvent.id === currEventInfo.id
-                            && oldEvent.sequence_num === currEventInfo.sequence_num
-                        // This represents deduplication on rapid consequent template changes
-                        || oldEvent.id !== currEventInfo.id
-                            && oldEvent.sequence_num <= currEventInfo.sequence_num);
-        })) {
-            return true;
-        }
-
-        this.latestMessages.push(currEventInfo);
-        if (this.latestMessages.length > DEDUPE_LOG_SIZE) {
-            this.latestMessages = this.latestMessages.slice(1);
-        }
-        return false;
-    }
-
     processTranscludes(hyper, req) {
         const message = req.body;
         const context = {
@@ -196,12 +205,6 @@ class DependencyProcessor {
             message
         };
         const originalEvent = req.body.original_event || req.body;
-
-        if (this._isDuplicate(message)) {
-            hyper.metrics.increment('transclusions_continue_deduplicate');
-            // Skip if duplication detected
-            return { status: 200 };
-        }
         return this._getSiteInfo(hyper, message)
         .then((siteInfo) => {
             const title = Title.newFromText(req.params.title, siteInfo);
@@ -223,7 +226,7 @@ class DependencyProcessor {
         .then((res) => {
             if (this.wikidataRequest.shouldProcess(res)) {
                 const items = this.wikidataRequest.extractResults(res);
-                return this._sendResourceChanges(hyper, items, req.body,
+                return _sendResourceChanges(hyper, items, req.body,
                     this.wikidataRequest.resourceChangeTags,
                     this.wikidataRequest.leafTopicName);
             }
@@ -252,61 +255,16 @@ class DependencyProcessor {
                 // the batch is complete or the list of transcluded titles is empty
                 return { status: 200 };
             }
-            let actions = this._sendResourceChanges(hyper, titles,
+            let actions = _sendResourceChanges(hyper, titles,
                 originalEvent, requestTemplate.resourceChangeTags,
                 requestTemplate.leafTopicName);
             if (res.body.continue) {
-                actions = actions.then(() =>
-                    this._sendContinueEvent(hyper,
+                actions = actions.then(() => _sendContinueEvent(hyper,
                         requestTemplate.leafTopicName,
                         originalEvent,
-                        requestTemplate.getContinueToken(res),
-                        context.message.sequence_num));
+                        requestTemplate.getContinueToken(res)));
             }
             return actions.thenReturn({ status: 200 });
-        });
-    }
-
-    _sendContinueEvent(hyper, topic, origEvent, continueToken, sequenceNum) {
-        return hyper.post({
-            uri: '/sys/queue/events',
-            body: [{
-                meta: {
-                    topic,
-                    schema_uri: 'continue/1',
-                    uri: origEvent.meta.uri,
-                    request_id: origEvent.meta.request_id,
-                    domain: origEvent.meta.domain,
-                    dt: origEvent.meta.dt
-                },
-                triggered_by: utils.triggeredBy(origEvent),
-                original_event: origEvent,
-                continue: continueToken,
-                sequence_num: (sequenceNum || 0) + 1
-            }]
-        });
-    }
-
-    _sendResourceChanges(hyper, items, originalEvent, tags, topicName) {
-        return hyper.post({
-            uri: '/sys/queue/events',
-            body: items.map((item) => {
-                // TODO: need to check whether a wiki is http or https!
-                const resourceURI =
-                    `https://${item.domain}/wiki/${encodeURIComponent(item.title)}`;
-                return {
-                    meta: {
-                        topic: topicName,
-                        schema_uri: 'resource_change/1',
-                        uri: resourceURI,
-                        request_id: originalEvent.meta.request_id,
-                        domain: item.domain,
-                        dt: originalEvent.meta.dt
-                    },
-                    triggered_by: utils.triggeredBy(originalEvent),
-                    tags
-                };
-            })
         });
     }
 

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -16,7 +16,7 @@ var ChangeProp = function(configPath) {
     this._config.num_workers = 0;
     this._config.logging = {
         name: 'change-prop',
-        level: 'fatal',
+        level: 'warn',
         streams: [{ type: 'stdout'}]
     };
     this._runner = new ServiceRunner();

--- a/test/utils/changeProp.js
+++ b/test/utils/changeProp.js
@@ -16,7 +16,7 @@ var ChangeProp = function(configPath) {
     this._config.num_workers = 0;
     this._config.logging = {
         name: 'change-prop',
-        level: 'warn',
+        level: 'fatal',
         streams: [{ type: 'stdout'}]
     };
     this._runner = new ServiceRunner();


### PR DESCRIPTION
So we're gonna take the same approach to deduplication as we do for blacklisting.

We will have a separate deduplicator module with a configured redistribution client and will unconditionally send all the messages to the deduplicator. Then it will, just like MediaWiki version, first check whether the message individually is a duplicate - e.g. if the message with exact same ID was recently processed by exact same rule. Also, if there's information about the `root_event` - attempt to deduplicate based on the root event.

This also switches the dependency processor to the new reduplication method. Will need to update schemas, but it doesn't really matter, because these events are not going via the proxy service, so the schemas are just for the documentation purposes.

@wikimedia/services 