### PR TITLE
Start travis testing on node 8 and drop node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 sudo: false
 
 node_js:
-  - "4"
   - "6"
+  - "8"
 
 env:
   - KAFKA_HOME=../kafka KAFKA_VERSION=0.9.0.1 CXX=g++-4.8

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "nock": "^9.0.13",
     "preq": "^0.5.2",
     "ajv": "^5.1.5",
-    "mocha-eslint":"^3.0.1",
+    "mocha-eslint": "^3.0.1",
     "eslint-config-node-services": "^2.2.1",
     "eslint-config-wikimedia": "^0.4.0",
     "eslint-plugin-jsdoc": "^3.1.0",


### PR DESCRIPTION
Time to go with node v8 in travis.

cc @wikimedia/services 