### PR TITLE
Separate kafka broker metrics by consumer group id

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -245,7 +245,7 @@ class KafkaFactory {
 
         let statCb;
         if (metrics) {
-            statCb = rdKafkaStatsdCb(metrics);
+            statCb = rdKafkaStatsdCb(metrics.makeChild(groupId));
             conf['statistics.interval.ms'] = STATS_INTERVAL;
         }
 


### PR DESCRIPTION
We're reporting a lot of metrics from the Kafka driver to statsd, but we were doing it all wrong. Each topic can be followed by multiple rules (consumers) and we want to build graphs per rule separately. Previously we didn't include the group_id in the metric name so metrics from multiple rules were mixed together.

cc @wikimedia/services 