### PR TITLE
Emit broker statistics more frequently

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -10,7 +10,7 @@ const rdKafkaStatsdCb = require('node-rdkafka-statsd');
  *
  * @type {number}
  */
-const STATS_INTERVAL = 60000;
+const STATS_INTERVAL = 5000;
 
 const CONSUMER_DEFAULTS = {
     // We don't want the driver to commit automatically the offset of just read message,


### PR DESCRIPTION
Emitting the client statistics every one minute is way too infrequent - stats can be lost as it's UDP and the graphs can't really be built. Try to emit the stats every 5 seconds.

cc @wikimedia/services 