### PR TITLE
Respect the `ignore_errors` config per-request

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -318,6 +318,12 @@ class BaseExecutor {
                     });
                     return this.hyper.request(request)
                     .tap(redirectCheck)
+                    .catch((e) => {
+                        if (this.rule.shouldIgnoreError(BaseExecutor.decodeError(e))) {
+                            return { status: 200 };
+                        }
+                        throw e;
+                    })
                     .tap(this._sampleLog.bind(this, retryEvent || origEvent, request))
                     .tapCatch(this._sampleLog.bind(this, retryEvent || origEvent, request));
                 })


### PR DESCRIPTION
We need to respect the `ignore_errors` spec on per-request level to avoid braking the request chain in case an ignored error occurs.

cc @wikimedia/services 