### PR TITLE
Log error stack when retry count is exceeded

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -372,7 +372,8 @@ class BaseExecutor {
                 event_str: utils.stringify(message),
                 status: e.status,
                 page: message.meta.uri,
-                description: `${e}`
+                description: e.message,
+                stack: e.stack
             }));
             return true;
         }


### PR DESCRIPTION
Sometimes the error message in logs is not enough to find out what's wrong and what's making us retry, report a stack as well

cc @wikimedia/services 