### PR TITLE
Optimize commited offset choosing

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -62,7 +62,6 @@ class BaseExecutor {
         this._commitTimeout = null;
         // In order ti filter out the pending messages faster make them offset->msg map
         this._pendingMsgs = new Map();
-        this._toCommit = undefined;
         this._consuming = false;
     }
 
@@ -171,13 +170,13 @@ class BaseExecutor {
         // Will throw if any of the limiters failed,
         // the error message will say which one is failed.
         .catch({ status: 429 }, (e) => {
-            this.log('error/ratelimit', {
+            this.log('error/ratelimit', () => ({
                 msg: 'Rate-limited message processing',
                 rule_name: this.rule.name,
                 limiter: e.body.message,
                 limiter_key: e.body.key,
                 event_str: utils.stringify(expander.message)
-            });
+            }));
             return true;
         });
     }
@@ -211,33 +210,29 @@ class BaseExecutor {
             return;
         }
 
-        if (this._pendingMsgs.size) {
-            this._toCommit = Math.min.apply(null, Array.from(this._pendingMsgs.keys()));
-        } else {
-            this._toCommit = finishedMsg;
-        }
-
         if (!this._commitTimeout) {
             this._commitTimeout = setTimeout(() => {
                 this._commitTimeout = null;
-                if (this._toCommit) {
-                    const committing = this._toCommit;
-                    return this.consumer.commitMessageAsync(committing)
-                    .then(() => {
-                        if (this._toCommit && this._toCommit.offset === committing.offset) {
-                            // Don't commit what we've just committed
-                            this._toCommit = undefined;
+                const minPendingOffset = () => {
+                    const offsetIterator = this._pendingMsgs.keys();
+                    let lowestOffset = Number.MAX_VALUE;
+                    for (const offset of offsetIterator) {
+                        if (offset < lowestOffset) {
+                            lowestOffset = offset;
                         }
-                    })
-                    .catch((e) => {
-                        this.log(`error/commit/${this.rule.name}`, {
-                            msg: 'Commit failed',
-                            offset: committing.offset,
-                            raw_event: committing.value.toString(),
-                            description: e.toString()
-                        });
-                    });
-                }
+                    }
+                    return lowestOffset;
+                };
+                const committing = this._pendingMsgs.size ? minPendingOffset() : finishedMsg;
+                return this.consumer.commitMessageAsync(committing)
+                .catch((e) => {
+                    this.log(`error/commit/${this.rule.name}`, () => ({
+                        msg: 'Commit failed',
+                        offset: committing.offset,
+                        raw_event: committing.value.toString(),
+                        description: e.toString()
+                    }));
+                });
             }, DEFAULT_COMMIT_INTERVAL);
         }
     }

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -213,17 +213,15 @@ class BaseExecutor {
         if (!this._commitTimeout) {
             this._commitTimeout = setTimeout(() => {
                 this._commitTimeout = null;
-                const minPendingOffset = () => {
-                    const offsetIterator = this._pendingMsgs.keys();
-                    let lowestOffset = Number.MAX_VALUE;
-                    for (const offset of offsetIterator) {
-                        if (offset < lowestOffset) {
-                            lowestOffset = offset;
+                let committing = finishedMsg;
+                // Not check if any of the pending messages have offset lower then finished msg
+                if (this._pendingMsgs.size) {
+                    for (const [offset, message] of this._pendingMsgs.entries()) {
+                        if (offset < committing.offset) {
+                            committing = message;
                         }
                     }
-                    return lowestOffset;
-                };
-                const committing = this._pendingMsgs.size ? minPendingOffset() : finishedMsg;
+                }
                 return this.consumer.commitMessageAsync(committing)
                 .catch((e) => {
                     this.log(`error/commit/${this.rule.name}`, () => ({

--- a/sys/deduplicator.js
+++ b/sys/deduplicator.js
@@ -37,10 +37,10 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
                 return NOT_DUPLICATE;
             }
             hyper.metrics.increment(`${name}_dedupe`);
-            hyper.log('trace/dedupe', {
+            hyper.log('trace/dedupe', () => ({
                 message: 'Event was deduplicated based on id',
                 event_str: utils.stringify(message),
-            });
+            }));
             return DUPLICATE;
         })
         .then((individualDeduplicated) => {
@@ -56,12 +56,12 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
                 if (oldEventTimestamp
                         && new Date(oldEventTimestamp) > new Date(message.root_event.dt)) {
                     hyper.metrics.increment(`${name}_dedupe`);
-                    hyper.log('trace/dedupe', {
+                    hyper.log('trace/dedupe', () => ({
                         message: 'Event was deduplicated based on root event',
                         event_str: utils.stringify(message),
                         signature: message.root_event.signature,
                         newer_dt: oldEventTimestamp
-                    });
+                    }));
                     return DUPLICATE;
                 }
                 return this._redis.setAsync(rootEventKey, message.root_event.dt)


### PR DESCRIPTION
Selecting the minimum offset to commit across pending messages is a pretty heavy operation - we need to iterate over the whole pending queue which could be quite big and select the minimal offset. However, we only commit once per commit interval (500ms) - so why don't we select the offset to commit once per 500 ms as well and not update it after each processed message? This can create a bit of a lag in the committed offsets for topics with low traffic, but it's totally fine - we will not reexecute already processed events because now we have redis-based deduplication.

According to my profiling this makes us significantly faster (at least it's one of the major contributors to object allocation and CPU usage in the JavaScript land

Additionally - use lazy-evaluation for trace logging - that was a big contributor to mem/cpu usage as well.

cc @wikimedia/services 
