### PR TITLE
Fixed sha1-based deduplication and added dedupe tests

### DIFF
--- a/config.jobqueue.wikimedia.yaml
+++ b/config.jobqueue.wikimedia.yaml
@@ -44,6 +44,15 @@ spec: &spec
                     content-type: application/json
                     host: '{{message.meta.domain}}'
                   body: '{{globals.message}}'
+              htmlCacheUpdate:
+                topic: 'mediawiki.job.htmlCacheUpdate'
+                exec:
+                  method: post
+                  uri: 'http://jobrunner.wikipedia.org/wiki/Special:RunSingleJob'
+                  headers:
+                    content-type: application/json
+                    host: '{{message.meta.domain}}'
+                  body: '{{globals.message}}'
 
 num_workers: 0
 logging:

--- a/test/feature/job_rules.js
+++ b/test/feature/job_rules.js
@@ -3,10 +3,11 @@
 const ChangeProp = require('../utils/changeProp');
 const nock = require('nock');
 const common = require('../utils/common');
+const P = require('bluebird');
 
 process.env.UV_THREADPOOL_SIZE = 128;
 
-describe('JobQueue rules', function () {
+describe('JobQueue rules', function() {
     this.timeout(30000);
 
     const changeProp = new ChangeProp('config.jobqueue.wikimedia.yaml');
@@ -17,25 +18,93 @@ describe('JobQueue rules', function () {
         this.timeout(50000);
         return changeProp.start()
         .then(() => common.factory.createProducer(console.log.bind(console)))
-        .then((result) => producer = result);
+        .then(result => producer = result);
     });
 
     [
         'updateBetaFeaturesUserCounts'
     ].forEach((jobType) => {
         it(`Should propagate ${jobType} job`, () => {
+            const sampleEvent = common.jobs[jobType];
             const service = nock('http://jobrunner.wikipedia.org', {
                 reqheaders: {
-                    host: common.jobs[jobType].meta.domain,
+                    host: sampleEvent.meta.domain,
                     'content-type': 'application/json'
                 }
             })
-            .post('/wiki/Special:RunSingleJob', common.jobs[jobType]).reply({});
+            .post('/wiki/Special:RunSingleJob', sampleEvent)
+            .reply({});
             return producer.produce(`test_dc.mediawiki.job.${jobType}`, 0,
-                Buffer.from(JSON.stringify(common.jobs[jobType])))
+                Buffer.from(JSON.stringify(sampleEvent)))
             .then(() => common.checkAPIDone(service))
             .finally(() => nock.cleanAll());
         });
+    });
+
+    it('Should deduplicate based on ID', () => {
+        const sampleEvent = common.jobs.updateBetaFeaturesUserCounts;
+        const service = nock('http://jobrunner.wikipedia.org', {
+            reqheaders: {
+                host: sampleEvent.meta.domain,
+                'content-type': 'application/json'
+            }
+        })
+        .post('/wiki/Special:RunSingleJob', sampleEvent)
+        .twice() // We set 2 mocks here in order to check that after the test 1 is still pending
+        .reply({});
+        return P.each([
+            JSON.stringify(sampleEvent),
+            JSON.stringify(sampleEvent)
+        ].map(strMsg => Buffer.from(strMsg)), msg =>
+            producer.produce('test_dc.mediawiki.job.updateBetaFeaturesUserCounts', 0, msg))
+        .then(() => common.checkPendingMocks(service, 1))
+        .finally(() => nock.cleanAll());
+    });
+
+    it('Should deduplicate based on SHA1', () => {
+        const firstEvent = common.jobs.updateBetaFeaturesUserCounts;
+        const secondEvent = common.jobs.updateBetaFeaturesUserCounts;
+        secondEvent.meta.dt = new Date(Date.now() - 1000).toISOString();
+        secondEvent.sha1 = firstEvent.sha1;
+        const service = nock('http://jobrunner.wikipedia.org', {
+            reqheaders: {
+                host: firstEvent.meta.domain,
+                'content-type': 'application/json'
+            }
+        })
+        .post('/wiki/Special:RunSingleJob', firstEvent)
+        .reply({})
+        // We specify a mock for the second event as well to checkout it's still pending after tests
+        .post('/wiki/Special:RunSingleJob', secondEvent)
+        .reply({});
+        return producer.produce('test_dc.mediawiki.job.updateBetaFeaturesUserCounts', 0, Buffer.from(JSON.stringify(firstEvent)))
+        .then(() => common.checkPendingMocks(service, 1))
+        .then(() => producer.produce('test_dc.mediawiki.job.updateBetaFeaturesUserCounts', 0, Buffer.from(JSON.stringify(secondEvent))))
+        .then(() => common.checkPendingMocks(service, 1))
+        .finally(() => nock.cleanAll());
+    });
+
+    it('Should deduplicate base on root job', () => {
+        const firstEvent = common.jobs.htmlCacheUpdate;
+        const secondEvent = common.jobs.htmlCacheUpdate;
+        secondEvent.root_event.signature = firstEvent.root_event.signature;
+        secondEvent.root_event.dt = new Date(new Date(firstEvent.root_event.dt) - 1000).toISOString();
+        const service = nock('http://jobrunner.wikipedia.org', {
+            reqheaders: {
+                host: firstEvent.meta.domain,
+                'content-type': 'application/json'
+            }
+        })
+        .post('/wiki/Special:RunSingleJob', firstEvent)
+        .reply({})
+        // We specify a mock for the second event as well to checkout it's still pending after tests
+        .post('/wiki/Special:RunSingleJob', secondEvent)
+        .reply({});
+        return producer.produce('test_dc.mediawiki.job.htmlCacheUpdate', 0, Buffer.from(JSON.stringify(firstEvent)))
+        .then(() => common.checkPendingMocks(service, 1))
+        .then(() => producer.produce('test_dc.mediawiki.job.htmlCacheUpdate', 0, Buffer.from(JSON.stringify(secondEvent))))
+        .then(() => common.checkPendingMocks(service, 1))
+        .finally(() => nock.cleanAll());
     });
 
     after(() => changeProp.stop());

--- a/test/utils/clean_kafka.sh
+++ b/test/utils/clean_kafka.sh
@@ -45,6 +45,8 @@ createTopic "test_dc.change-prop.wikidata.resource-change"
 createTopic "test_dc.change-prop.retry.change-prop.wikidata.resource-change"
 createTopic "test_dc.mediawiki.job.updateBetaFeaturesUserCounts"
 createTopic "test_dc.change-prop.retry.mediawiki.job.updateBetaFeaturesUserCounts"
+createTopic "test_dc.mediawiki.job.htmlCacheUpdate"
+createTopic "test_dc.change-prop.retry.mediawiki.job.htmlCacheUpdate"
 
 wait
 sleep 5

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -39,10 +39,10 @@ common.eventWithMessageAndRandom = (message, random) => {
     });
 };
 
-common.randomString = () => {
+common.randomString = (len = 5) => {
     const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     let text = '';
-    while (text.length < 5) {
+    while (text.length < len) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
     }
     return text;
@@ -121,27 +121,63 @@ common.factory = new KafkaFactory({
 // Sample JobQueue events
 
 common.jobs = {
-    updateBetaFeaturesUserCounts: {
-        "database": "enwiki",
-        "meta": {
-            "domain": "en.wikipedia.org",
-            "dt": "2017-09-05T02:08:52+00:00",
-            "id": "29e4bc47-91df-11e7-83b0-14187761316a",
-            "request_id": "d402f64b-7343-4d92-8eea-957eca4fd308",
-            "schema_uri": "mediawiki/job/1",
-            "topic": "mediawiki.job.updateBetaFeaturesUserCounts",
-            "uri": "https://en.wikipedia.org/wiki/Main_Page"
-        },
-        "page_namespace": 0,
-        "page_title": "Main_Page",
-        "params": {
-            "prefs": [
-                "visualeditor-newwikitext"
-            ],
-            "requestId": "Wa4HNApAAEMAAHzG8r4AAAAE"
-        },
-        "sha1": "b63122a8f7ae2ff8578c76eb215e08cbf6560e8f",
-        "type": "updateBetaFeaturesUserCounts"
+    get updateBetaFeaturesUserCounts() {
+        return {
+            "database": "enwiki",
+            "meta": {
+                "domain": "en.wikipedia.org",
+                "dt": new Date().toISOString(),
+                "id": uuid.now().toString(),
+                "request_id": common.randomString(10),
+                "schema_uri": "mediawiki/job/1",
+                "topic": "mediawiki.job.updateBetaFeaturesUserCounts",
+                "uri": "https://en.wikipedia.org/wiki/Main_Page"
+            },
+            "page_namespace": 0,
+            "page_title": "Main_Page",
+            "params": {
+                "prefs": [
+                    "visualeditor-newwikitext"
+                ],
+                "requestId": "Wa4HNApAAEMAAHzG8r4AAAAE"
+            },
+            "sha1": common.randomString(20),
+            "type": "updateBetaFeaturesUserCounts"
+        };
+    },
+    get htmlCacheUpdate() {
+        const rootSignature = common.randomString(10);
+        return {
+            "database": "commonswiki",
+            "mediawiki_signature": common.randomString(10),
+            "meta": {
+                "domain": "commons.wikimedia.org",
+                "dt": new Date().toISOString(),
+                "id": uuid.now().toString(),
+                "request_id": common.randomString(10),
+                "schema_uri": "mediawiki/job/1",
+                "topic": "mediawiki.job.htmlCacheUpdate",
+                "uri": "https://commons.wikimedia.org/wiki/File:%D0%A1%D1%82%D0%B0%D0%B2%D0%BE%D0%BA_-_panoramio_(6).jpg"
+            },
+            "page_namespace": 6,
+            "page_title": "File:Ставок_-_panoramio_(6).jpg",
+            "params": {
+                "causeAction": "page-edit",
+                "causeAgent": "unknown",
+                "recursive": true,
+                "requestId": "Wi7xIQpAANEAAEs6jxcAAACE",
+                "rootJobIsSelf": true,
+                "rootJobSignature": rootSignature,
+                "rootJobTimestamp": "20171211205706",
+                "table": "redirect"
+            },
+            "root_event": {
+                "dt": new Date().toISOString(),
+                "signature": rootSignature
+            },
+            "sha1": common.randomString(10),
+            "type": "htmlCacheUpdate"
+        };
     }
 };
 


### PR DESCRIPTION
Made it correctly check for `sha1`-based duplicates - only dedup if we've encountered an event with  `sha1` but did execute an event with the same `sha1` after the encountered event was created. 

Also add tests for deduplication features - for ID-based, sha1-based and root _event-based dedup.

cc @wikimedia/services 