### PR TITLE
Added jobqueue configuration for kubernetes

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -6,4 +6,3 @@ WORKDIR /opt/service
 ENV HOME=/root LINK=g++ BUILD_LIBRDKAFKA="0" IN_DOCKER=1 UV_THREADPOOL_SIZE=128
 RUN rm -rf ./node_modules && npm install && npm dedupe
 COPY ./kubernetes/config.yaml /etc/config.yaml
-CMD node /opt/service/server.js -c /etc/config.yaml

--- a/kubernetes/config.changeprop.yaml
+++ b/kubernetes/config.changeprop.yaml
@@ -29,7 +29,6 @@ spec: &spec
             startup_delay: 0
             concurrency: 250
             templates:
-
               summary_definition_rerender: &summary_definition_rerender_spec
                 topic: '/^(?:change-prop\.transcludes\.)?resource[-_]change$/'
                 retry_limit: 2

--- a/kubernetes/config.jobqueue.yaml
+++ b/kubernetes/config.jobqueue.yaml
@@ -1,0 +1,49 @@
+spec: &spec
+  x-sub-request-filters:
+    - type: default
+      name: http
+      options:
+        allow:
+          - pattern: /^https?:\/\//
+            forward_headers:
+              user-agent: true
+  title: The Change Propagation root
+  paths:
+    /sys/dedupe:
+      x-modules:
+        - path: sys/deduplicator.js
+          options:
+            redis_prefix: CPJQ
+            redis:
+              host: '{env(REDIS_HOST)}'
+              port: '{env(REDIS_PORT)}'
+    /sys/queue:
+      x-modules:
+        - path: sys/kafka.js
+          options:
+            metadata_broker_list: '{env(KAFKA_BROKER_LIST)}'
+            dc_name: eqiad
+            startup_delay: 0
+            concurrency: 250
+            templates:
+              job:
+                topic: '/mediawiki\.job\..*'
+                exec:
+                  method: post
+                  uri: '{env(MEDIAWIKI_URI)}/wiki/Special:RunSingleJob'
+                  headers:
+                    content-type: application/json
+                    host: '{{message.meta.domain}}'
+                  body: '{{globals.message}}'
+
+num_workers: 0
+logging:
+  name: changeprop
+  level: info
+services:
+  - name: changeprop
+    module: hyperswitch
+    conf:
+      port: 7272
+      user_agent: JobQueuePropInstance
+      spec: *spec


### PR DESCRIPTION
In order to add an experimental configuration to the `mediawiki-services` the container has to include a config for the JobQueue. The container will be reused for both CP and JobQueue, so I've removed the specific CMP - kubernetes will decide what each of the containers will run.

I think in future these configs will ho into helm templates though, but this is a quick solution to add CPJobQueue to our experimental kubernetes setup.

cc @wikimedia/services 