### PR TITLE
librdkafka: Use the main APT pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         {
           "repo_url": "https://apt.wikimedia.org/wikimedia",
           "release": "jessie-wikimedia",
-          "pool": "backports",
+          "pool": "main",
           "packages": [
             "librdkafka-dev"
           ]


### PR DESCRIPTION
Bug: [T185016](https://phabricator.wikimedia.org/T185016)
Bug: [T176126](https://phabricator.wikimedia.org/T176126)