### PR TITLE
Update node-rdkafka driver to version 2

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -16,6 +16,8 @@ const CONSUMER_DEFAULTS = {
     // We don't want the driver to commit automatically the offset of just read message,
     // we will handle offsets manually.
     'enable.auto.commit': 'false',
+    'api.version.request': 'false',
+    'broker.version.fallback': '0.9.0'
 };
 
 const CONSUMER_TOPIC_DEFAULTS = {
@@ -25,7 +27,9 @@ const CONSUMER_TOPIC_DEFAULTS = {
 };
 
 const PRODUCER_DEFAULTS = {
-    dr_cb: true
+    dr_cb: true,
+    'api.version.request': 'false',
+    'broker.version.fallback': '0.9.0'
 };
 
 const PRODUCER_TOPIC_DEFAULTS = {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "htcp-purge": "^0.2.2",
     "mediawiki-title": "^0.6.3",
     "murmur-32": "^0.1.0",
-    "node-rdkafka": "^1.0.6",
+    "node-rdkafka": "^2.2.1",
     "node-rdkafka-statsd": "^0.1.0",
     "ratelimit.js": "^1.8.0",
     "redis": "^2.7.1"
@@ -82,7 +82,7 @@
         {
           "repo_url": "https://apt.wikimedia.org/wikimedia",
           "release": "jessie-wikimedia",
-          "pool": "backports",
+          "pool": "main",
           "packages": [
             "librdkafka-dev"
           ]


### PR DESCRIPTION
Node-rdkafka version 2+ requires librdkafka 0.11+ that we are going
to upgrade to. The new librdkafka supports Kafka 0.9, however, it
first issues a request to Kafka for supported API version but Kafka 0.9
doesn't support this feature yet, so we have to switch it off until we
migrate Kafka to 0.10+

All the unit tests pass locally, but I propose to proceed with caution -
we can install librdkafka 0.11 on the beta cluster and let it run there
for a while. Also, we can randomly kill brokers in beta and see how it reacts.
Local testing of such things is normally non-conclusive.

cc @wikimedia/services @lavagetto 