### PR TITLE
Stop using node-rdkafka-statsd callback.

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -3,14 +3,6 @@
 const kafka = require('node-rdkafka');
 const P = require('bluebird');
 const EventEmitter = require('events').EventEmitter;
-const rdKafkaStatsdCb = require('node-rdkafka-statsd');
-
-/**
- * How often to report statistics. Once per minute is more then enough.
- *
- * @type {number}
- */
-const STATS_INTERVAL = 5000;
 
 const CONSUMER_DEFAULTS = {
     // We don't want the driver to commit automatically the offset of just read message,
@@ -248,12 +240,6 @@ class KafkaFactory {
         conf['group.id'] = groupId;
         conf['client.id'] = `${Math.floor(Math.random() * 1000000)}`;
 
-        let statCb;
-        if (metrics) {
-            statCb = rdKafkaStatsdCb(metrics.makeChild(groupId));
-            conf['statistics.interval.ms'] = STATS_INTERVAL;
-        }
-
         return new P((resolve, reject) => {
             const consumer = new kafka.KafkaConsumer(conf, this._consumerTopicConf);
             consumer.connect(undefined, (err) => {
@@ -261,16 +247,6 @@ class KafkaFactory {
                     return reject(err);
                 }
                 consumer.subscribe([ topic ]);
-                if (statCb) {
-                    consumer.on('event.stats', (stat) => {
-                        try {
-                            statCb(stat);
-                        } catch (e) {
-                            // Just to make 100% sure we don't kill
-                            // the application on metrics error.
-                        }
-                    });
-                }
                 resolve(P.promisifyAll(consumer));
             });
         });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "mediawiki-title": "^0.6.3",
     "murmur-32": "^0.1.0",
     "node-rdkafka": "^2.2.1",
-    "node-rdkafka-statsd": "^0.1.0",
     "ratelimit.js": "^1.8.0",
     "redis": "^2.7.1"
   },


### PR DESCRIPTION
Librdkafka is capable of sending various stats,
but over the last year of using the callback and
reporting the stats we were unable to find any
really useful use-case for them. The callback
generates a lot of traffic, so let's just stop
using it.

cc @wikimedia/services @ottomata