### PR TITLE
Rerender summary after mobile-sections.

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -81,9 +81,10 @@ spec: &spec
                 cases: # Non wiktionary domains - rerender summary
                   - match:
                       meta:
-                        uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>[^/]+)$/'
+                        uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/mobile-sections\/(?<title>[^/]+)$/'
                       tags:
                         - restbase
+                        - mobile-sections
                     match_not:
                       - meta:
                           domain: '/wiktionary.org$/'
@@ -101,10 +102,11 @@ spec: &spec
                       meta:
                         # These URIs are coming from RESTBase, so we know that article titles will be normalized
                         # and main namespace articles will not have : (uri-encoded, so %3a or %3A)
-                        uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/html\/(?<title>(?:(?!%3a|%3A|\/).)+)$/'
+                        uri: '/^(?<proto>https?):\/\/[^\/]+\/api\/rest_v1\/page\/mobile-sections\/(?<title>(?:(?!%3a|%3A|\/).)+)$/'
                         domain: '/^en\.wiktionary\.org$/'
                       tags:
                         - restbase
+                        - mobile-sections
                     exec:
                       method: get
                       # Don't encode title since it should be already encoded
@@ -173,14 +175,9 @@ spec: &spec
                       if-unmodified-since: '{{date(message.meta.dt)}}'
                     query:
                       redirect: false
-                    # The HTML might not change but sometimes editors use a purge to drop incorrectly rendered summary/MCS
-                    # content, so let's purge them as well just in case. The rate is low.
-                  - method: get
-                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{decode(match.meta.uri.title)}'
-                    headers:
-                      cache-control: no-cache
-                    query:
-                      redirect: false
+                    # The HTML might not change but sometimes editors use a purge to drop incorrectly rendered MCS
+                    # content, so let's purge them as well just in case. The rate is low. MCS rerender will cause summary
+                    # to be rerendered
                   - method: get
                     uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{decode(match.meta.uri.title)}'
                     headers:
@@ -211,13 +208,8 @@ spec: &spec
                     query:
                       redirect: false
                       # The HTML might not change but sometimes editors use a purge to drop incorrectly rendered summary/MCS
-                      # content, so let's purge them as well just in case. The rate is low.
-                  - method: get
-                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{decode(match.meta.uri.title)}'
-                    headers:
-                      cache-control: no-cache
-                    query:
-                      redirect: false
+                      # content, so let's purge them as well just in case. The rate is low. MCS rerender will cause summary
+                      # to be rerendered
                   - method: get
                     uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{decode(match.meta.uri.title)}'
                     headers:
@@ -651,18 +643,12 @@ spec: &spec
                     uri: '/https:\/\/[^\/]+\/wiki\/(?<title>.+)/'
                   tags: [ 'wikidata' ]
                 exec:
-                  - method: get
-                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{{match.meta.uri.title}}'
-                    headers:
-                      cache-control: no-cache
-                    query:
-                      redirect: false
-                  - method: get
-                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
-                    headers:
-                      cache-control: no-cache
-                    query:
-                      redirect: false
+                  method: get
+                  uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{{match.meta.uri.title}}'
+                  headers:
+                    cache-control: no-cache
+                  query:
+                    redirect: false
               page_images:
                 topic: mediawiki.page-properties-change
                 # We don't support 'OR' in the match section, so workaround it by 2 cases with identical exec
@@ -678,18 +664,12 @@ spec: &spec
                           domain: /\.wikidata\.org$/
                         page_namespace: 120
                     exec:
-                      - method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{message.page_title}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
-                      - method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{message.page_title}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
+                      method: get
+                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{message.page_title}'
+                      headers:
+                        cache-control: no-cache
+                      query:
+                        redirect: false
                   - match:
                       removed_properties:
                         page_image: '/.+/' # Regex that matches anything just to check the prop is set
@@ -697,19 +677,12 @@ spec: &spec
                       meta:
                         domain: /\.wikidata\.org$/
                     exec:
-                      - method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{message.page_title}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
-                      - method: get
-                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{message.page_title}'
-                        headers:
-                          cache-control: no-cache
-                        query:
-                          redirect: false
-
+                      method: get
+                      uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{message.page_title}'
+                      headers:
+                        cache-control: no-cache
+                      query:
+                        redirect: false
 num_workers: 0
 logging:
   name: changeprop

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -54,7 +54,7 @@ describe('RESTBase update rules', function() {
         const mwAPI = nock('https://en.wikipedia.org', {
             reqheaders: {
                 'cache-control': 'no-cache',
-                'x-triggered-by': `req:${common.SAMPLE_REQUEST_ID},${topic}:https://en.wikipedia.org/api/rest_v1/page/html/Main_Page`,
+                'x-triggered-by': `req:${common.SAMPLE_REQUEST_ID},${topic}:https://en.wikipedia.org/api/rest_v1/page/mobile-sections/Main_Page`,
                 'user-agent': 'SampleChangePropInstance'
             }
         })
@@ -67,13 +67,13 @@ describe('RESTBase update rules', function() {
                 meta: {
                     topic: topic,
                     schema_uri: 'resource_change/1',
-                    uri: 'https://en.wikipedia.org/api/rest_v1/page/html/Main_Page',
+                    uri: 'https://en.wikipedia.org/api/rest_v1/page/mobile-sections/Main_Page',
                     request_id: common.SAMPLE_REQUEST_ID,
                     id: uuid.now(),
                     dt: new Date().toISOString(),
                     domain: 'en.wikipedia.org'
                 },
-                tags: ['restbase']
+                tags: ['restbase', 'mobile-sections']
             }))))
         .then(() => common.checkAPIDone(mwAPI))
         .finally(() => nock.cleanAll());
@@ -87,7 +87,7 @@ describe('RESTBase update rules', function() {
     it('Should update summary endpoint, transcludes topic', () =>
         summaryEndpointTest('change-prop.transcludes.resource-change'));
 
-    it('Should update summary endpoint on page images change', () => {
+    it('Should update mobile-sections endpoint on page images change', () => {
         const mwAPI = nock('https://en.wikipedia.org', {
             reqheaders: {
                 'cache-control': 'no-cache',
@@ -95,7 +95,7 @@ describe('RESTBase update rules', function() {
                 'user-agent': 'SampleChangePropInstance'
             }
         })
-        .get('/api/rest_v1/page/summary/Some_Page')
+        .get('/api/rest_v1/page/mobile-sections/Some_Page')
         .query({ redirect: false })
         .reply(200, { });
 
@@ -123,7 +123,7 @@ describe('RESTBase update rules', function() {
         const mwAPI = nock('https://en.wiktionary.org', {
             reqheaders: {
                 'cache-control': 'no-cache',
-                'x-triggered-by': `req:${common.SAMPLE_REQUEST_ID},resource_change:https://en.wiktionary.org/api/rest_v1/page/html/Main_Page`,
+                'x-triggered-by': `req:${common.SAMPLE_REQUEST_ID},resource_change:https://en.wiktionary.org/api/rest_v1/mobile-sections/html/Main_Page`,
                 'user-agent': 'SampleChangePropInstance'
             }
         })
@@ -136,13 +136,13 @@ describe('RESTBase update rules', function() {
                 meta: {
                     topic: 'resource_change',
                     schema_uri: 'resource_change/1',
-                    uri: 'https://en.wiktionary.org/api/rest_v1/page/html/Main_Page',
+                    uri: 'https://en.wiktionary.org/api/rest_v1/page/mobile-sections/Main_Page',
                     request_id: common.SAMPLE_REQUEST_ID,
                     id: uuid.now(),
                     dt: new Date().toISOString(),
                     domain: 'en.wiktionary.org'
                 },
-                tags: ['restbase']
+                tags: ['restbase', 'mobile-sections']
             }))))
         .then(() => common.checkAPIDone(mwAPI))
         .finally(() => nock.cleanAll());
@@ -516,9 +516,6 @@ describe('RESTBase update rules', function() {
                 'x-triggered-by': `req:${common.SAMPLE_REQUEST_ID},mediawiki.revision-create:/rev/uri,change-prop.wikidata.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80`
             }
         })
-        .get('/api/rest_v1/page/summary/%D0%9F%D1%91%D1%82%D1%80')
-        .query({ redirect: false })
-        .reply(200, { })
         .get('/api/rest_v1/page/mobile-sections/%D0%9F%D1%91%D1%82%D1%80')
         .query({ redirect: false })
         .reply(200, { });
@@ -581,9 +578,6 @@ describe('RESTBase update rules', function() {
                 'x-triggered-by': `req:${common.SAMPLE_REQUEST_ID},mediawiki.revision-create:/rev/uri,change-prop.wikidata.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80`
             }
         })
-        .get('/api/rest_v1/page/summary/%D0%9F%D1%91%D1%82%D1%80')
-        .query({ redirect: false })
-        .reply(200, { })
         .get('/api/rest_v1/page/mobile-sections/%D0%9F%D1%91%D1%82%D1%80')
         .query({ redirect: false })
         .reply(200, { });
@@ -645,9 +639,6 @@ describe('RESTBase update rules', function() {
                 'x-triggered-by': `req:${common.SAMPLE_REQUEST_ID},mediawiki.page-undelete:/rev/uri,change-prop.wikidata.resource-change:https://ru.wikipedia.org/wiki/%D0%9F%D1%91%D1%82%D1%80`
             }
         })
-        .get('/api/rest_v1/page/summary/%D0%9F%D1%91%D1%82%D1%80')
-        .query({ redirect: false })
-        .reply(200, { })
         .get('/api/rest_v1/page/mobile-sections/%D0%9F%D1%91%D1%82%D1%80')
         .query({ redirect: false })
         .reply(200, { });


### PR DESCRIPTION
MCS will use cached mobile-sections-lead to generate the summary,
so summary must only be rerendered after the mobile-sections-lead
update is completed.

Bug: T184753
cc @wikimedia/services @wikimedia/mobile 