### PR TITLE
Delay message fetch attempt if the consumer is in errored state.

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -131,9 +131,14 @@ class BaseExecutor {
                 case kafka.CODES.ERRORS.ERR__TIMED_OUT:
                     // We're reading to fast, nothing is there, slow down a little bit
                     return P.delay(100);
-
                 default:
                     this.log(`error/consumer/${this.rule.name}`, e);
+                    if (e.code === kafka.CODES.ERRORS.ERR__STATE) {
+                        // KafkaConsumer is disconnected or entered error state.
+                        // Give it some time to reconnect before the new attempt
+                        // to fetch messages again to avoid a tight loop
+                        return P.delay(1000);
+                    }
             }
             /* eslint-enable indent */
         })


### PR DESCRIPTION
When the consumer gets disconnected from Kafka an attempt to fetch
a message fails almost instantly, so we get into a tight loop
unless we add the a delay before the next attempt. That causes
a worker to die.

@wikimedia/services 