### PR TITLE
Revert "Revert the move to node-rdkafka 2.0"

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -7,7 +7,9 @@ const EventEmitter = require('events').EventEmitter;
 const CONSUMER_DEFAULTS = {
     // We don't want the driver to commit automatically the offset of just read message,
     // we will handle offsets manually.
-    'enable.auto.commit': 'false'
+    'enable.auto.commit': 'false',
+    'api.version.request': 'false',
+    'broker.version.fallback': '0.9.0'
 };
 
 const CONSUMER_TOPIC_DEFAULTS = {
@@ -17,7 +19,9 @@ const CONSUMER_TOPIC_DEFAULTS = {
 };
 
 const PRODUCER_DEFAULTS = {
-    dr_cb: true
+    dr_cb: true,
+    'api.version.request': 'false',
+    'broker.version.fallback': '0.9.0'
 };
 
 const PRODUCER_TOPIC_DEFAULTS = {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "htcp-purge": "^0.2.2",
     "mediawiki-title": "^0.6.5",
     "murmur-32": "^0.1.0",
-    "node-rdkafka": "^1.0.6",
+    "node-rdkafka": "^2.2.1",
     "ratelimit.js": "^1.8.0",
     "redis": "^2.7.1"
   },
@@ -81,7 +81,7 @@
         {
           "repo_url": "https://apt.wikimedia.org/wikimedia",
           "release": "jessie-wikimedia",
-          "pool": "backports",
+          "pool": "main",
           "packages": [
             "librdkafka-dev"
           ]


### PR DESCRIPTION
Reverts wikimedia/change-propagation#230

We need to finally upgrade to node-rdkafka v2 because right now we can't really deploy ChangeProp in SCB.

This depends on updating librdkafka on SCB and a coordinated deploy together with EventStreams.

cc @wikimedia/services @ottomata 