### PR TITLE
Support delayed job execution.

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -307,7 +307,7 @@ class BaseExecutor {
                 }
                 // The exec time is to soon to re-enqueue - just wait and execute
                 return P.delay(timeLeft + 1)
-                .then(() => _exec(origEvent, handler, statDelayStartTime, retryEvent));
+                .then(() => this._exec(origEvent, handler, statDelayStartTime, retryEvent));
             }
         }
 

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -292,15 +292,22 @@ class BaseExecutor {
         if (origEvent.delay_until) {
             // The delay_until in the job schema is a timestamps in seconds
             const delayUntil = origEvent.delay_until * 1000;
+            const now = Date.now();
             if (delayUntil > Date.now()) {
-                // Not ready to execute yet - delay for some time and put back to the queue
-                return P.delay(10000)
-                .then(() => {
-                    return this.hyper.post({
-                        uri: new URI('/sys/queue/events'),
-                        body: [ origEvent ]
+                const timeLeft = delayUntil - now;
+                if (timeLeft > 20000) {
+                    // Not ready to execute yet - delay for some time and put back to the queue
+                    return P.delay(20000)
+                    .then(() => {
+                        return this.hyper.post({
+                            uri: new URI('/sys/queue/events'),
+                            body: [ origEvent ]
+                        });
                     });
-                });
+                }
+                // The exec time is to soon to re-enqueue - just wait and execute
+                return P.delay(timeLeft + 1)
+                .then(() => _exec(origEvent, handler, statDelayStartTime, retryEvent));
             }
         }
 

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -289,6 +289,21 @@ class BaseExecutor {
             match: handler.expand(origEvent)
         };
 
+        if (origEvent.delay_until) {
+            // The delay_until in the job schema is a timestamps in seconds
+            const delayUntil = origEvent.delay_until * 1000;
+            if (delayUntil > Date.now()) {
+                // Not ready to execute yet - delay for some time and put back to the queue
+                return P.delay(10000)
+                .then(() => {
+                    return this.hyper.post({
+                        uri: new URI('/sys/queue/events'),
+                        body: [ origEvent ]
+                    });
+                });
+            }
+        }
+
         if (handler.sampler && !handler.sampler.accept(expander)) {
             this.log(`trace/${rule.name}`, () => ({
                 msg: 'Disregarding event; Filtered by sampler',

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -24,14 +24,16 @@ class Kafka {
         this.staticRules = options.templates || {};
 
         this.subscriber = new RuleSubscriber(options, this.kafkaFactory);
-        HyperSwitch.lifecycle.on('close', () => this.subscriber.unsubscribeAll());
     }
 
     setup(hyper) {
         return this.kafkaFactory.createGuaranteedProducer(this.log)
         .then((producer) => {
             this.producer = producer;
-            HyperSwitch.lifecycle.on('close', () => this.producer.disconnect());
+            HyperSwitch.lifecycle.once('close', () => {
+                this.subscriber.unsubscribeAll();
+                this.producer.disconnect();
+            });
             return this._subscribeRules(hyper, this.staticRules);
         })
         .tap(() => this.log('info/change-prop/init', 'Kafka Queue module initialised'));


### PR DESCRIPTION
If the delayed job functionality is not configurable (basically we rely on the event having a delay_until field in a very specific format, then delayed job execution becomes trivial the idea is that we dequeue a message, if the message is ready to be executed - we execute. If not - we wait for 10 seconds and put the message back to the queue to give ourselves a chance to process some more messages. 

I'm not quite sure how to create a unit test for this though, but manual testing shows it works great. Also perhaps we need to add some instrumentation and custom metrics to the delayed functionality. And it's interesting whether you think relying on the `delay_until` field format and not making this configurable is ok.

Bug: T186261
cc @wikimedia/services 