### PR TITLE
Revert "Log partition assignment/revoking for rebalancing"

### DIFF
--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -9,8 +9,7 @@ const CONSUMER_DEFAULTS = {
     // we will handle offsets manually.
     'enable.auto.commit': 'false',
     'api.version.request': 'false',
-    'broker.version.fallback': '0.9.0',
-    rebalance_cb: true
+    'broker.version.fallback': '0.9.0'
 };
 
 const CONSUMER_TOPIC_DEFAULTS = {
@@ -191,7 +190,6 @@ class KafkaFactory {
             throw new Error('metadata_broker_list property is required for the kafka config');
         }
 
-        this._log = kafkaConf.log || (() => {});
         this._kafkaConf = kafkaConf;
 
         this._consumerTopicConf = Object.assign({}, CONSUMER_TOPIC_DEFAULTS,
@@ -244,33 +242,6 @@ class KafkaFactory {
 
         return new P((resolve, reject) => {
             const consumer = new kafka.KafkaConsumer(conf, this._consumerTopicConf);
-            consumer.on('rebalance', (err, assignments) => {
-                // The librdkafka rebalance callback uses `err` to signal whether
-                // the partition was assigned or unassigned, so err will always be
-                // defined.
-                switch (err.code) {
-                    case kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS:
-                        if (assignments.length) {
-                            this._log('info/consumer/rebalance', {
-                                msg: 'Consumer assigned partitions',
-                                assignment: JSON.stringify(assignments),
-                                groupId
-                            });
-                        }
-                        break;
-                    case kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS:
-                        if (assignments.length) {
-                            this._log('info/consumer/rebalance', {
-                                msg: 'Consumer revoked partitions',
-                                assignment: JSON.stringify(assignments),
-                                groupId
-                            });
-                        }
-                        break;
-                    default:
-                        this._log('error/consumer/rebalance', err);
-                }
-            });
             consumer.connect(undefined, (err) => {
                 if (err) {
                     return reject(err);
@@ -298,12 +269,12 @@ class KafkaFactory {
         .then(consumer => new MetadataWatch(consumer, this.consumeDC)._setup());
     }
 
-    _createProducerOfClass(ProducerClass) {
+    _createProducerOfClass(ProducerClass, log) {
         return new P((resolve, reject) => {
             const producer = new ProducerClass(
                 this._producerConf,
                 this._producerTopicConf,
-                this._log
+                log || (() => {})
             );
             producer.once('event.error', reject);
             producer.connect(undefined, (err) => {
@@ -316,12 +287,12 @@ class KafkaFactory {
 
     }
 
-    createProducer() {
-        return this._createProducerOfClass(AutopollingProducer);
+    createProducer(log) {
+        return this._createProducerOfClass(AutopollingProducer, log);
     }
 
-    createGuaranteedProducer() {
-        return this._createProducerOfClass(GuaranteedProducer);
+    createGuaranteedProducer(log) {
+        return this._createProducerOfClass(GuaranteedProducer, log);
     }
 }
 module.exports = KafkaFactory;

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -24,14 +24,14 @@ class Kafka {
         this.staticRules = options.templates || {};
 
         this.subscriber = new RuleSubscriber(options, this.kafkaFactory);
-        HyperSwitch.lifecycle.once('close', () => this.subscriber.unsubscribeAll());
+        HyperSwitch.lifecycle.on('close', () => this.subscriber.unsubscribeAll());
     }
 
     setup(hyper) {
-        return this.kafkaFactory.createGuaranteedProducer()
+        return this.kafkaFactory.createGuaranteedProducer(this.log)
         .then((producer) => {
             this.producer = producer;
-            HyperSwitch.lifecycle.once('close', () => this.producer.disconnect());
+            HyperSwitch.lifecycle.on('close', () => this.producer.disconnect());
             return this._subscribeRules(hyper, this.staticRules);
         })
         .tap(() => this.log('info/change-prop/init', 'Kafka Queue module initialised'));

--- a/test/feature/job_rules.js
+++ b/test/feature/job_rules.js
@@ -17,7 +17,7 @@ describe('JobQueue rules', function() {
         // Setting up might take some tome, so disable the timeout
         this.timeout(50000);
         return changeProp.start()
-        .then(() => common.factory.createProducer())
+        .then(() => common.factory.createProducer(console.log.bind(console)))
         .then(result => producer = result);
     });
 

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -29,7 +29,7 @@ describe('Basic rule management', function() {
         .then((res) => retrySchema = yaml.safeLoad(res.body))
         .then(() => preq.get({ uri: 'https://raw.githubusercontent.com/wikimedia/mediawiki-event-schemas/master/jsonschema/error/1.yaml' }))
         .then((res) => errorSchema = yaml.safeLoad(res.body))
-        .then(() => common.factory.createProducer())
+        .then(() => common.factory.createProducer(console.log.bind(console)))
         .then((result) => producer = result);
     });
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -35,7 +35,7 @@ describe('RESTBase update rules', function() {
             });
         })
         .then((res) => siteInfoResponse = res.body)
-        .then(() => common.factory.createProducer())
+        .then(() => common.factory.createProducer(console.log.bind(console)))
         .then((result) => producer = result);
     });
 

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -114,8 +114,7 @@ common.factory = new KafkaFactory({
         "fetch.wait.max.ms": "1",
         "fetch.min.bytes": "1",
         "queue.buffering.max.ms": "1"
-    },
-    log: console.log.bind(console)
+    }
 });
 
 


### PR DESCRIPTION
Reverts wikimedia/change-propagation#234

That patch has broken out tests due to a bug in node-rdkafka. Also, this might affect the restarting of the service in production (the workers get stuck trying to disconnect), so until the underlying issue in node-rdkafka is resolved I think it's better to revert it to be on the safe side.