### PR TITLE
Support multi-topic rules.

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -99,7 +99,11 @@ class BaseExecutor {
                 return P.delay(100);
             }
 
-            this.hyper.metrics.increment(`${this.statName}_dequeue`, messages.length, 0.1);
+            messages.forEach(message =>
+                this.hyper.metrics.increment(
+                    `${this.statName(message.meta.topic)}_dequeue`,
+                    1,
+                    0.1));
 
             messages.forEach((msg) => {
                 const message = this._safeParse(msg.value.toString('utf8'));
@@ -337,14 +341,14 @@ class BaseExecutor {
 
         // Latency from the event (if it's a retry - an original event)
         // creation time to execution time
-        this.hyper.metrics.endTiming([`${this.statName}_delay`],
+        this.hyper.metrics.endTiming([`${this.statName(origEvent.meta.topic)}_delay`],
             statDelayStartTime || new Date(origEvent.meta.dt));
 
         // This metric doesn't make much sense for retries
         if (origEvent.root_event && !retryEvent) {
             // Latency from the beginning of the recursive event chain
             // to the event execution
-            this.hyper.metrics.endTiming([`${this.statName}_totaldelay`],
+            this.hyper.metrics.endTiming([`${this.statName(origEvent.meta.topic)}_totaldelay`],
                 new Date(origEvent.root_event.dt));
         }
 
@@ -389,7 +393,10 @@ class BaseExecutor {
                 })
                 .tap(() => this._updateLimiters(expander, 200))
                 .tapCatch(e => this._updateLimiters(expander, e.status))
-                .finally(() => this.hyper.metrics.endTiming([`${this.statName}_exec`], startTime));
+                .finally(() => this.hyper.metrics.endTiming(
+                    [`${this.statName(origEvent.meta.topic)}_exec`],
+                    startTime)
+                );
             });
         });
     }

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -69,7 +69,7 @@ class BaseExecutor {
         const prefix = this.options.test_mode ? `test-change-prop` : `change-prop`;
         return this.kafkaFactory.createConsumer(
             `${prefix}-${this.rule.name}`,
-            this.subscribeTopic,
+            this.subscribeTopics,
             this.hyper.metrics
         )
         .then((consumer) => {
@@ -394,8 +394,8 @@ class BaseExecutor {
         });
     }
 
-    _retryTopicName() {
-        return `change-prop.retry.${this.rule.topic}`;
+    _retryTopicName(topic) {
+        return `change-prop.retry.${topic}`;
     }
 
     _emitterId() {
@@ -405,7 +405,7 @@ class BaseExecutor {
     _constructRetryMessage(event, errorRes, retriesLeft, retryEvent) {
         return {
             meta: {
-                topic: this._retryTopicName(),
+                topic: this._retryTopicName(event.meta.topic),
                 schema_uri: 'retry/1',
                 uri: event.meta.uri,
                 domain: event.meta.domain
@@ -450,7 +450,7 @@ class BaseExecutor {
         if (e.constructor.name !== 'HTTPError') {
             // We've got an error, but it's not from the update request, it's
             // some bug in change-prop. Log and send a fatal error message.
-            this.hyper.log(`error/${this.rule.name}`, () => ({
+            this.hyper.log(`fatal/${this.rule.name}`, () => ({
                 message: 'Internal error in change-prop',
                 description: `${e}`,
                 stack: e.stack,

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -99,14 +99,13 @@ class BaseExecutor {
                 return P.delay(100);
             }
 
-            messages.forEach(message =>
+            messages.forEach((msg) => {
+                const message = this._safeParse(msg.value.toString('utf8'));
+
                 this.hyper.metrics.increment(
                     `${this.statName(message.meta.topic)}_dequeue`,
                     1,
-                    0.1));
-
-            messages.forEach((msg) => {
-                const message = this._safeParse(msg.value.toString('utf8'));
+                    0.1);
 
                 const handler = this.getHandler(message);
                 if (handler) {

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -130,12 +130,11 @@ class MetadataWatch extends EventEmitter {
             this._refreshInterval = setInterval(() => {
                 this.getTopics()
                 .then((topics) => {
-                    // TODO:emit info when topic is removed (although it's impossible in prod)
-                    topics.forEach((newTopic) => {
-                        if (this._knownTopics.indexOf(newTopic) < 0) {
-                            this.emit('topic_added', newTopic);
-                        }
-                    });
+                    const topicsAdded = topics
+                    .some(newTopic => this._knownTopics.indexOf(newTopic) < 0);
+                    if (topicsAdded) {
+                        this.emit('topics_changed', topics);
+                    }
                     this._knownTopics = topics;
                 })
                 .catch(e => this.emit('error', e));
@@ -232,10 +231,10 @@ class KafkaFactory {
     /**
      * Create new KafkaConsumer and connect it.
      * @param {string} groupId Consumer group ID to use
-     * @param {string} topic Topic to subscribe to
+     * @param {Array} topics Topics to subscribe to
      * @param {Object} [metrics] metrics reporter
      */
-    createConsumer(groupId, topic, metrics) {
+    createConsumer(groupId, topics, metrics) {
         const conf = Object.assign({}, this._consumerConf);
         conf['group.id'] = groupId;
         conf['client.id'] = `${Math.floor(Math.random() * 1000000)}`;
@@ -246,7 +245,7 @@ class KafkaFactory {
                 if (err) {
                     return reject(err);
                 }
-                consumer.subscribe([ topic ]);
+                consumer.subscribe(topics);
                 resolve(P.promisifyAll(consumer));
             });
         });

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -8,8 +8,9 @@ const BaseExecutor = require('./base_executor');
  * A rule executor managing matching and execution of a single rule
  */
 class RetryExecutor extends BaseExecutor {
-    get subscribeTopic() {
-        return `${this.kafkaFactory.consumeDC}.${this._retryTopicName()}`;
+    get subscribeTopics() {
+        return this.rule.topics.map(topic =>
+            `${this.kafkaFactory.consumeDC}.${this._retryTopicName(topic)}`);
     }
 
     get statName() {

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -13,8 +13,8 @@ class RetryExecutor extends BaseExecutor {
             `${this.kafkaFactory.consumeDC}.${this._retryTopicName(topic)}`);
     }
 
-    get statName() {
-        return this.hyper.metrics.normalizeName(`${this.rule.name}_retry`);
+    statName(topic) {
+        return this.hyper.metrics.normalizeName(`${this.rule.name}-${topic}_retry`);
     }
 
     _delay(message) {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -137,17 +137,11 @@ class Rule {
         this.name = name;
         this.spec = spec || {};
 
-        const  topic = this.spec.topic;
-        if (!topic || typeof topic !== 'string' || !topic.length) {
-            throw new Error(`No topic specified for rule ${this.name}`);
+        const topics = this.spec.topics || (this.spec.topic && [ this.spec.topic ]);
+        if (!topics || !Array.isArray(topics) || !topics.length) {
+            throw new Error(`No topics specified for rule ${this.name}`);
         }
-
-        if (/^\/.+\/$/.test(topic)) {
-            // Ok, we've got a regex topic! Compile the regex.
-            this.topic = new RegExp(topic.substring(1, topic.length - 1));
-        } else {
-            this.topic = topic;
-        }
+        this.topics = topics;
 
         this.spec.retry_on = this.spec.retry_on || {
             status: [ '50x' ]
@@ -195,6 +189,17 @@ class Rule {
         });
     }
 
+    static isBasicRule(ruleSpec) {
+        const topics = ruleSpec.topics || [ ruleSpec.topic ];
+        return !topics.some(topic => /^\/.+\/$/.test(topic));
+    }
+
+    static newWithTopicNames(ruleName, ruleSpec, topicNames) {
+        const newSpec = Object.assign({}, ruleSpec);
+        newSpec.topics = topicNames;
+        return new Rule(ruleName, newSpec);
+    }
+
     /**
      * Whether the claim_ttl or root_claim_ttl has passed and the event should be abandoned
      * @param {Object} message the event to check
@@ -212,10 +217,6 @@ class Rule {
             return true;
         }
         return false;
-    }
-
-    isRegexRule() {
-        return this.topic instanceof RegExp;
     }
 
     _processMatchNot(matchNot) {
@@ -330,13 +331,6 @@ class Rule {
             templates.push(new Template(req));
         }
         return templates;
-    }
-
-    clone(newTopic) {
-        const newSpec = Object.assign({}, this.spec);
-        const newName = `${this.name}-${newTopic.replace(/\./g, '_')}`;
-        newSpec.topic = newTopic;
-        return new Rule(newName, newSpec);
     }
 }
 

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -7,8 +7,8 @@ const URI = require('hyperswitch').URI;
  * A rule executor managing matching and execution of a single rule
  */
 class RuleExecutor extends BaseExecutor {
-    get subscribeTopic() {
-        return `${this.kafkaFactory.consumeDC}.${this.rule.topic}`;
+    get subscribeTopics() {
+        return this.rule.topics.map(topic => `${this.kafkaFactory.consumeDC}.${topic}`);
     }
 
     get statName() {

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -11,8 +11,8 @@ class RuleExecutor extends BaseExecutor {
         return this.rule.topics.map(topic => `${this.kafkaFactory.consumeDC}.${topic}`);
     }
 
-    get statName() {
-        return this.hyper.metrics.normalizeName(this.rule.name);
+    statName(topic) {
+        return this.hyper.metrics.normalizeName(`${this.rule.name}-${topic}`);
     }
 
     /**

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -53,7 +53,7 @@ class RegexTopicSubscription {
         this._hyper = hyper;
         this._ruleName = ruleName;
         this._ruleSpec = ruleSpec;
-        this._topicTester = ruleSpec.topics || (ruleSpec.topic && [ ruleSpec.topic ])
+        this._topicTester = (ruleSpec.topics || (ruleSpec.topic && [ ruleSpec.topic ]))
         .map((topic) => {
             if (/^\/.+\/$/.test(topic)) {
                 // Ok, we've got a regex topic! Compile the regex.

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -2,19 +2,20 @@
 
 const RuleExecutor = require('./rule_executor');
 const RetryExecutor = require('./retry_executor');
+const Rule = require('./rule');
 const P = require('bluebird');
 
 class BasicSubscription {
-    constructor(options, kafkaFactory, hyper, rule) {
+    constructor(options, kafkaFactory, hyper, ruleName, ruleSpec) {
         this._kafkaFactory = kafkaFactory;
         this._options = options;
         this._log = this._options.log || (() => {});
-        this._rule = rule;
+        this._rule = new Rule(ruleName, ruleSpec);
 
         this._subscribed = false;
-        this._executor = new RuleExecutor(rule, this._kafkaFactory,
+        this._executor = new RuleExecutor(this._rule, this._kafkaFactory,
             hyper, this._log, this._options);
-        this._retryExecutor = new RetryExecutor(rule, this._kafkaFactory,
+        this._retryExecutor = new RetryExecutor(this._rule, this._kafkaFactory,
             hyper, this._log, this._options);
     }
 
@@ -24,9 +25,9 @@ class BasicSubscription {
         }
 
         this._log('info/subscription', {
-            message: 'Subscribing based on basic topic',
+            message: 'Subscribing based on basic topics',
             rule: this._rule.name,
-            topic: this._rule.topic
+            topics: this._rule.topics
         });
 
         return P.join(this._executor.subscribe(), this._retryExecutor.subscribe())
@@ -42,19 +43,27 @@ class BasicSubscription {
         }
     }
 }
-
+// TODO: rewrite this one
 class RegexTopicSubscription {
-    constructor(options, kafkaFactory, hyper, rule, metadataWatch) {
+    constructor(options, kafkaFactory, hyper, ruleName, ruleSpec, metadataWatch) {
         this._kafkaFactory = kafkaFactory;
         this._options = options;
         this._log = this._options.log || (() => {});
         this._hyper = hyper;
-        this._rule = rule;
-        this._metadataWatch = metadataWatch;
-        this._metadataWatch.on('topic_added', (topic) => {
-            if (this._rule.topic.test(topic)) {
-                this._subscribeTopic(topic);
+        this._ruleName = ruleName;
+        this._ruleSpec = ruleSpec;
+        this._topicTester = ruleSpec.topics || (ruleSpec.topic && [ ruleSpec.topic ])
+        .map((topic) => {
+            if (/^\/.+\/$/.test(topic)) {
+                // Ok, we've got a regex topic! Compile the regex.
+                return new RegExp(topic.substring(1, topic.length - 1));
             }
+            return topic;
+        });
+        this._metadataWatch = metadataWatch;
+        this._metadataWatch.on('topics_changed', (topics) => {
+            this.unsubscribe();
+            this._subscribeTopics(topics);
         });
         // Ignore the emitted errors - in 10 seconds it will retry
         this._metadataWatch.on('error', e => this._log('error/metadata_refresh', e));
@@ -63,13 +72,33 @@ class RegexTopicSubscription {
         this._executors = [];
     }
 
-    _subscribeTopic(topicName) {
-        const topicRule = this._rule.clone(topicName);
+    /**
+     * Filters out which topic names are ok to subscribe to.
+     * @param {Array} proposedTopicNames a set of available topic names
+     *                to check which to subscribe to
+     * @return {Array}
+     * @private
+     */
+    _filterTopics(proposedTopicNames) {
+        return proposedTopicNames.filter((topic) => {
+            return this._topicTester.some((topicTester) => {
+                if (topicTester instanceof RegExp) {
+                    return topicTester.test(topic);
+                }
+                return topicTester === topic;
+            });
+        });
+    }
+
+    _subscribeTopics(topicNames) {
+        const filteredTopics = this._filterTopics(topicNames);
+        const topicRule = Rule.newWithTopicNames(this._ruleName,
+            this._ruleSpec, filteredTopics);
 
         this._log('info/subscription', {
             message: 'Subscribing based on regex',
-            rule: this._rule.name,
-            topic: topicName
+            rule: this._ruleName,
+            topics: filteredTopics
         });
 
         const executor = new RuleExecutor(topicRule, this._kafkaFactory,
@@ -88,17 +117,12 @@ class RegexTopicSubscription {
 
     subscribe() {
         return this._metadataWatch.getTopics()
-        .then((topics) => {
-            const selectedTopics = topics.filter(topic => this._rule.topic.test(topic));
-
-            return P.each(selectedTopics, (topicName) => {
-                return this._subscribeTopic(topicName);
-            });
-        });
+        .then(topics => this._subscribeTopics(topics));
     }
 
     unsubscribe() {
         if (this._subscribed) {
+            this._subscribed = false;
             this._executors.forEach(executor => executor.close());
         }
     }
@@ -113,10 +137,10 @@ class Subscriber {
         this._metadataWatch = undefined;
     }
 
-    _createSubscription(hyper, rule) {
-        if (!rule.isRegexRule()) {
+    _createSubscription(hyper, ruleName, ruleSpec) {
+        if (Rule.isBasicRule(ruleSpec)) {
             return P.resolve(new BasicSubscription(this._options,
-                this._kafkaFactory, hyper, rule));
+                this._kafkaFactory, hyper, ruleName, ruleSpec));
         }
         let maybeCreateWatchAction;
         if (!this._metadataWatch) {
@@ -131,11 +155,18 @@ class Subscriber {
 
         return maybeCreateWatchAction
         .then(() => new RegexTopicSubscription(this._options, this._kafkaFactory,
-            hyper, rule, this._metadataWatch));
+            hyper, ruleName, ruleSpec, this._metadataWatch));
     }
 
-    subscribe(hyper, rule) {
-        return this._createSubscription(hyper, rule)
+    /**
+     * Subscribe a rule spec under a certain rule name
+     * @param {HyperSwitch} hyper the request dispatcher
+     * @param {string} ruleName the name of the rule
+     * @param {Object} ruleSpec the rule specification
+     * @return {Promise}
+     */
+    subscribe(hyper, ruleName, ruleSpec) {
+        return this._createSubscription(hyper, ruleName, ruleSpec)
         .then((subscription) => {
             this._subscriptions.push(subscription);
             return subscription.subscribe();

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -4,6 +4,7 @@ const RuleExecutor = require('./rule_executor');
 const RetryExecutor = require('./retry_executor');
 const Rule = require('./rule');
 const P = require('bluebird');
+const stringify = require('json-stable-stringify');
 
 class BasicSubscription {
     constructor(options, kafkaFactory, hyper, ruleName, ruleSpec) {
@@ -62,14 +63,18 @@ class RegexTopicSubscription {
         });
         this._metadataWatch = metadataWatch;
         this._metadataWatch.on('topics_changed', (topics) => {
-            this.unsubscribe();
-            this._subscribeTopics(topics);
+            const newFilteredTopics = this._filterTopics(topics);
+            if (stringify(newFilteredTopics) !== stringify(this._filteredTopics)) {
+                this.unsubscribe();
+                this._subscribeTopics(topics);
+            }
         });
         // Ignore the emitted errors - in 10 seconds it will retry
         this._metadataWatch.on('error', e => this._log('error/metadata_refresh', e));
 
         this._subscribed = false;
         this._executors = [];
+        this._filteredTopics = undefined;
     }
 
     /**
@@ -87,18 +92,18 @@ class RegexTopicSubscription {
                 }
                 return topicTester === topic;
             });
-        });
+        }).sort();
     }
 
     _subscribeTopics(topicNames) {
-        const filteredTopics = this._filterTopics(topicNames);
+        this._filteredTopics = topicNames;
         const topicRule = Rule.newWithTopicNames(this._ruleName,
-            this._ruleSpec, filteredTopics);
+            this._ruleSpec, this._filteredTopics);
 
         this._log('info/subscription', {
             message: 'Subscribing based on regex',
             rule: this._ruleName,
-            topics: filteredTopics
+            topics: this._filteredTopics
         });
 
         const executor = new RuleExecutor(topicRule, this._kafkaFactory,
@@ -117,7 +122,7 @@ class RegexTopicSubscription {
 
     subscribe() {
         return this._metadataWatch.getTopics()
-        .then(topics => this._subscribeTopics(topics));
+        .then(topics => this._subscribeTopics(this._filterTopics(topics)));
     }
 
     unsubscribe() {

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -12,7 +12,6 @@ const HTTPError = HyperSwitch.HTTPError;
 const uuid = require('cassandra-uuid').TimeUuid;
 
 const utils = require('../lib/utils');
-const Rule = require('../lib/rule');
 const KafkaFactory = require('../lib/kafka_factory');
 const RuleSubscriber = require('../lib/rule_subscriber');
 
@@ -40,12 +39,8 @@ class Kafka {
     }
 
     _subscribeRules(hyper, rules) {
-        const activeRules = Object.keys(rules)
-            .map(ruleName => new Rule(ruleName, rules[ruleName]))
-            .filter(rule => !rule.noop);
-
-        return P.each(activeRules, rule =>
-            this.subscriber.subscribe(hyper, rule))
+        return P.map(Object.keys(rules), ruleName =>
+            this.subscriber.subscribe(hyper, ruleName, rules[ruleName]))
         .thenReturn({ status: 201 });
     }
 

--- a/test/feature/job_rules.js
+++ b/test/feature/job_rules.js
@@ -44,7 +44,7 @@ describe('JobQueue rules', function() {
     it('Should support partitioned refreshLinks', () => {
         const sampleEvent = common.jobs.refreshLinks;
         const sampleEventCopy = JSON.parse(JSON.stringify(sampleEvent));
-        sampleEventCopy.meta.topic += '_partitioned';
+        sampleEventCopy.meta.topic = 'change-prop.partitioned.mediawiki.job.refreshLinks';
         const service = nock('http://jobrunner.wikipedia.org', {
             reqheaders: {
                 host: sampleEvent.meta.domain,

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -159,7 +159,7 @@ describe('Basic rule management', function() {
 
         return common.factory.createConsumer(
             'change-prop-test-consumer-valid-retry',
-            'test_dc.change-prop.retry.simple_test_rule' )
+            [ 'test_dc.change-prop.retry.simple_test_rule' ])
         .then((retryConsumer) => {
             setTimeout(() => producer.produce('test_dc.simple_test_rule', 0,
                 Buffer.from(JSON.stringify(common.eventWithMessageAndRandom('test', random)))), 2000);
@@ -290,7 +290,7 @@ describe('Basic rule management', function() {
     it('Should emit valid messages to error topic', () => {
         return common.factory.createConsumer(
             'change-prop-test-error-consumer',
-            'test_dc.change-prop.error')
+            [ 'test_dc.change-prop.error' ])
         .then((errorConsumer) => {
             setTimeout(() =>
                 producer.produce('test_dc.simple_test_rule', 0, Buffer.from('not_a_json_message')), 2000);

--- a/test/utils/clean_kafka.sh
+++ b/test/utils/clean_kafka.sh
@@ -49,8 +49,8 @@ createTopic "test_dc.mediawiki.job.htmlCacheUpdate"
 createTopic "test_dc.change-prop.retry.mediawiki.job.htmlCacheUpdate"
 createTopic "test_dc.mediawiki.job.refreshLinks"
 createTopic "test_dc.change-prop.retry.mediawiki.job.refreshLinks"
-createTopic "test_dc.mediawiki.job.refreshLinks_partitioned"  8
-createTopic "test_dc.change-prop.retry.mediawiki.job.refreshLinks_partitioned" 8
+createTopic "test_dc.change-prop.partitioned.mediawiki.job.refreshLinks"  8
+createTopic "test_dc.change-prop.retry.change-prop.partitioned.mediawiki.job.refreshLinks" 8
 
 wait
 sleep 5


### PR DESCRIPTION
As we've decided, for the JobQueue we need to support multi-topic rules that will share a single worker and this patch does just that.

Changes: 
1. Added support for array-based rules. All the rules that subscribe to multiple topics share a single worker now. This needs adjusting in normal change-prop config, because there we use regex-based rules differently.
2. This changes the metric names - all the topics subscribed to a single rule will share the metric name, so we need to decide what to go with metrics. Whatever we decide we will probably loose metric continuity.
3. This lacks the `exclusive rule` feature that would allow to ignore all the topics that other rules were subscribed to already, but it's pretty easy to implement with a config stanza.

TODO: Add a test for resubscription when the existing topics dynamically change

Bug: https://phabricator.wikimedia.org/T191238
cc @wikimedia/services 