### PR TITLE
Added tests for delayed execution

### DIFF
--- a/config.jobqueue.wikimedia.yaml
+++ b/config.jobqueue.wikimedia.yaml
@@ -34,9 +34,12 @@ spec: &spec
             producer:
               queue.buffering.max.messages: "10"
             concurrency: 250
+            reenqueue_delay: 5
             templates:
-              updateBetaFeaturesUserCounts:
-                topic: 'mediawiki.job.updateBetaFeaturesUserCounts'
+              normal_job_rule:
+                topics:
+                  - 'mediawiki.job.updateBetaFeaturesUserCounts'
+                  - 'mediawiki.job.cdnPurge'
                 exec:
                   method: post
                   uri: 'http://jobrunner.wikipedia.org/wiki/Special:RunSingleJob'

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -33,6 +33,15 @@ const DEFAULT_COMMIT_INTERVAL = 500;
  */
 const DEFAULT_CONSUMER_BATCH_SIZE = 1;
 
+/**
+ * The default delay before we re-enqueue the message with delay_until set.
+ * Measured in seconds
+ *
+ * @const
+ * @type {number}
+ */
+const DEFAULT_MINIMUM_RE_ENQUEUE_DELAY = 20;
+
 class BaseExecutor {
 
     /**
@@ -58,6 +67,9 @@ class BaseExecutor {
         this.consumerBatchSize = rule.spec.consumer_batch_size
             || this.options.consumer_batch_size
             || DEFAULT_CONSUMER_BATCH_SIZE;
+        this.reenqueue_delay = (rule.spec.reenqueue_delay
+            || this.options.reenqueue_delay
+            || DEFAULT_MINIMUM_RE_ENQUEUE_DELAY) * 1000;
 
         this._commitTimeout = null;
         // In order ti filter out the pending messages faster make them offset->msg map
@@ -302,9 +314,9 @@ class BaseExecutor {
             const now = Date.now();
             if (delayUntil > Date.now()) {
                 const timeLeft = delayUntil - now;
-                if (timeLeft > 20000) {
+                if (timeLeft > this.reenqueue_delay) {
                     // Not ready to execute yet - delay for some time and put back to the queue
-                    return P.delay(20000)
+                    return P.delay(this.reenqueue_delay)
                     .then(() => {
                         return this.hyper.post({
                             uri: new URI('/sys/queue/events'),

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -443,13 +443,14 @@ class BaseExecutor {
             original_event: event,
             error_status: errorRes && errorRes.status
         };
-        if (errorRes && errorRes.body && typeof res.body === 'object') {
+        if (errorRes && errorRes.body && typeof errorRes.body === 'object') {
             result.reason = (errorRes.body.title || errorRes.body.message);
         } else if (errorRes && errorRes.body && typeof errorRes.body === 'string') {
             // Sometimes MediaWiki will send us error body as HTML,
             // for PHP fatals or 503 for example. Record it for easier debugging.
             result.reason = errorRes.body;
         }
+        return result;
     }
 
     /**

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -213,6 +213,33 @@ common.jobs = {
             "sha1": "9dfd2116c8c597c6b377a9100c670e21de20bf70",
             "type": "refreshLinks"
         }
+    },
+    get cdnPurge() {
+        const releaseTimestamp = Date.now() / 1000 + 3;
+        return {
+            "database": "commonswiki",
+            "delay_until": `${releaseTimestamp}`,
+            "mediawiki_signature": "e6ff5af8f89ac6441c6ad7b34bdcf44fb1746c1ef6e07d8b9653c75d0005193e",
+            "meta": {
+                "domain": "commons.wikimedia.org",
+                "dt": new Date().toISOString(),
+                "id": uuid.now().toString(),
+                "request_id": common.randomString(10),
+                "schema_uri": "mediawiki/job/1",
+                "topic": "mediawiki.job.cdnPurge",
+                "uri": "https://commons.wikimedia.org/wiki/Special:Badtitle/CdnCacheUpdate"
+            },
+            "page_namespace": -1,
+            "page_title": "Special:Badtitle/CdnCacheUpdate",
+            "params": {
+                "jobReleaseTimestamp": releaseTimestamp,
+                "requestId": common.randomString(10),
+                "urls": [
+                    "https://commons.wikimedia.org/wiki/Main_Page"
+                ]
+            },
+            "type": "cdnPurge"
+        }
     }
 };
 


### PR DESCRIPTION
Apparently, we don't need to create the topics before hand.

cc @wikimedia/services 