### PR TITLE
Added support for specifying a sampler per rule and globally

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -178,8 +178,8 @@ class Rule {
             };
             if (option.sample) {
                 result.sampler = new Sampler(option.sample);
-            } else if (this.spec.sampler) {
-                result.sampler = new Sampler(this.spec.sampler);
+            } else if (this.spec.sample) {
+                result.sample = new Sampler(this.spec.sample);
             }
             return result;
         });

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -176,14 +176,10 @@ class Rule {
                 expand: matcher.expand,
                 match_not: this._processMatchNot(option.match_not)
             };
-            // TODO: Support more global sampler. For example, if case of
-            // `cases` stanza is used, we need to be able to fallback to
-            // the more global sample stanza from the higher-leve spec.
-            // TODO: possibly support specifying the `sample` options on the
-            // sys/kafka module level and assign it to all the rules when
-            // they're created in the _subscribeRules method.
             if (option.sample) {
                 result.sampler = new Sampler(option.sample);
+            } else if (this.spec.sampler) {
+                result.sampler = new Sampler(this.spec.sampler);
             }
             return result;
         });

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -179,7 +179,7 @@ class Rule {
             if (option.sample) {
                 result.sampler = new Sampler(option.sample);
             } else if (this.spec.sample) {
-                result.sample = new Sampler(this.spec.sample);
+                result.sampler = new Sampler(this.spec.sample);
             }
             return result;
         });

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -53,7 +53,7 @@ class RegexTopicSubscription {
         this._hyper = hyper;
         this._ruleName = ruleName;
         this._ruleSpec = ruleSpec;
-        ruleSpec.sampler =  ruleSpec.sampler || options.sampler;
+        ruleSpec.sample =  ruleSpec.sample || options.sample;
         this._topicTester = (ruleSpec.topics || (ruleSpec.topic && [ ruleSpec.topic ]))
         .map((topic) => {
             if (/^\/.+\/$/.test(topic)) {

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -11,8 +11,8 @@ class BasicSubscription {
         this._kafkaFactory = kafkaFactory;
         this._options = options;
         this._log = this._options.log || (() => {});
+        ruleSpec.sampler =  ruleSpec.sampler || options.sampler;
         this._rule = new Rule(ruleName, ruleSpec);
-
         this._subscribed = false;
         this._executor = new RuleExecutor(this._rule, this._kafkaFactory,
             hyper, this._log, this._options);
@@ -53,6 +53,7 @@ class RegexTopicSubscription {
         this._hyper = hyper;
         this._ruleName = ruleName;
         this._ruleSpec = ruleSpec;
+        ruleSpec.sampler =  ruleSpec.sampler || options.sampler;
         this._topicTester = (ruleSpec.topics || (ruleSpec.topic && [ ruleSpec.topic ]))
         .map((topic) => {
             if (/^\/.+\/$/.test(topic)) {

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -11,7 +11,7 @@ class BasicSubscription {
         this._kafkaFactory = kafkaFactory;
         this._options = options;
         this._log = this._options.log || (() => {});
-        ruleSpec.sampler =  ruleSpec.sampler || options.sampler;
+        ruleSpec.sample =  ruleSpec.sample || options.sample;
         this._rule = new Rule(ruleName, ruleSpec);
         this._subscribed = false;
         this._executor = new RuleExecutor(this._rule, this._kafkaFactory,


### PR DESCRIPTION
We've only supported samper per execution-case basis, but not per-rule (for rules with different cases) and not globally. This adds support for those possibilities.

cc @wikimedia/services 