### PR TITLE
Record HTML errors from MW in retry message

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -409,7 +409,7 @@ class BaseExecutor {
     }
 
     _constructRetryMessage(event, errorRes, retriesLeft, retryEvent) {
-        return {
+        const result = {
             meta: {
                 topic: this._retryTopicName(event.meta.topic),
                 schema_uri: 'retry/1',
@@ -420,9 +420,15 @@ class BaseExecutor {
             emitter_id: this._emitterId(),
             retries_left: retriesLeft === undefined ? this.rule.spec.retry_limit : retriesLeft,
             original_event: event,
-            reason: errorRes && errorRes.body && (errorRes.body.title || errorRes.body.message),
             error_status: errorRes && errorRes.status
         };
+        if (errorRes && errorRes.body && typeof res.body === 'object') {
+            result.reason = (errorRes.body.title || errorRes.body.message);
+        } else if (errorRes && errorRes.body && typeof errorRes.body === 'string') {
+            // Sometimes MediaWiki will send us error body as HTML,
+            // for PHP fatals or 503 for example. Record it for easier debugging.
+            result.reason = errorRes.body;
+        }
     }
 
     /**


### PR DESCRIPTION
Example when this happened: T192085

cc @wikimedia/services 