### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,32 +39,32 @@
     "cassandra-uuid": "^0.0.2",
     "extend": "^3.0.1",
     "hyperswitch": "^0.9.6",
-    "service-runner": "^2.4.8",
+    "service-runner": "^2.5.2",
     "json-stable-stringify": "^1.0.1",
-    "htcp-purge": "^0.2.2",
+    "htcp-purge": "^0.3.0",
     "mediawiki-title": "^0.6.5",
     "murmur-32": "^0.1.0",
     "node-rdkafka": "2.3.1",
     "ratelimit.js": "^1.8.0",
-    "redis": "^2.7.1"
+    "redis": "^2.8.0"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",
     "mocha": "^3.4.2",
     "mocha-jshint": "^2.3.1",
     "mocha-lcov-reporter": "^1.3.0",
-    "coveralls": "^2.13.1",
-    "js-yaml": "^3.8.4",
-    "nock": "^9.0.13",
-    "preq": "^0.5.2",
-    "ajv": "^5.1.5",
+    "coveralls": "^3.0.0",
+    "js-yaml": "^3.11.0",
+    "nock": "^9.2.5",
+    "preq": "^0.5.6",
+    "ajv": "^5.5.2",
     "mocha-eslint": "^4.1.0",
-    "eslint": "^4.12.0",
+    "eslint": "^4.19.1",
     "eslint-config-node-services": "^2.2.5",
     "eslint-config-wikimedia": "^0.5.0",
-    "eslint-plugin-jsdoc": "^3.1.0",
+    "eslint-plugin-jsdoc": "^3.6.3",
     "eslint-plugin-json": "^1.2.0",
-    "kafka-test-tools": "^0.1.2"
+    "kafka-test-tools": "^0.1.5"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Not ready to update `mocha` - it now needs the tests to shut doesn't cleanly and for change-prop clean shutdown requires some more work.

Not ready to update AJV - it now supports JSON-schema draft-v07 and apparently our draft-04 schemas are not entirely valid.

node-rdkafka should be fixed, the newer version breaks the build on mac.

cc @wikimedia/services 