### PR TITLE
Commit offsets for unmatched messages from time to time

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -25,6 +25,23 @@ const DEFAULT_CONCURRENCY = 30;
 const DEFAULT_COMMIT_INTERVAL = 500;
 
 /**
+ * Probability of committing the offset in case the particular message
+ * did not match the rule. For some rules like null edits in change-prop
+ * the rule match is very unprobably, because they reuse a common topic
+ * with many other rules that fire way more frequently.
+ *
+ * If we only commit messages when they match, that can create a large
+ * false backlog - after a restart a lot of messages can be reread and
+ * continuosly rejected.
+ *
+ * To avoid it, commit offsets of the rejected messages from time to time.
+ *
+ * @const
+ * @type {number}
+ */
+const NO_MATCH_COMMIT_PROBABILITY = 0.01;
+
+/**
  * The default number of messages to consume at once
  * For low-volume topics this must be one to avoid big delays in consumption.
  *
@@ -122,6 +139,9 @@ class BaseExecutor {
                             this._consume();
                         }
                     });
+                } else if (Math.random() < NO_MATCH_COMMIT_PROBABILITY) {
+                    // Again, do not return the promise as the commit can be done async
+                    this._notifyFinished(msg);
                 }
             });
         })


### PR DESCRIPTION
For some rules like null edits in change-prop the rule match
is very unprobably, because they reuse a common topic with
many other rules that fire way more frequently.

If we only commit messages when they match, that can create a large
false backlog - after a restart a lot of messages can be reread and
continuosly rejected.

cc @wikimedia/services 

To avoid it, commit offsets of the rejected messages from time to time.