### PR TITLE
Log proper topic list we're subscribing to for regex rules

### DIFF
--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -104,7 +104,7 @@ class RegexTopicSubscription {
         this._log('info/subscription', {
             message: 'Subscribing based on regex',
             rule: this._ruleName,
-            topics: this._filteredTopics
+            topics: topicRule.topics
         });
 
         const executor = new RuleExecutor(topicRule, this._kafkaFactory,


### PR DESCRIPTION
The `topicRule` might apply some additional filtering for regex rules based on the excluded topics config, so log that instead of the original topics that matched the regex.

cc @wikimedia/services 