### PR TITLE
Improve logging and adapt to the new hyper logger exposure.

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -57,19 +57,21 @@ class BaseExecutor {
      * @param {Rule} rule
      * @param {KafkaFactory} kafkaFactory
      * @param {Object} hyper
-     * @param {Function} log
      * @param {Object} options
      * @class
      */
-    constructor(rule, kafkaFactory, hyper, log, options) {
+    constructor(rule, kafkaFactory, hyper, options) {
         if (this.constructor.name === 'BaseExecutor') {
             throw new Error('BaseService is abstract. Create Master or Worker instance.');
         }
 
         this.rule = rule;
         this.kafkaFactory = kafkaFactory;
-        this.hyper = hyper;
-        this.log = log;
+        this._hyper = hyper;
+        this._logger = this._hyper.logger.child({
+            rule_name: this.rule.name,
+            executor: this.constructor.name
+        });
         this.options = options;
         this.concurrency = rule.spec.concurrency || this.options.concurrency || DEFAULT_CONCURRENCY;
         this.consumerBatchSize = rule.spec.consumer_batch_size
@@ -87,7 +89,7 @@ class BaseExecutor {
         return this.kafkaFactory.createConsumer(
             `${prefix}-${this.rule.name}`,
             this.subscribeTopics,
-            this.hyper.metrics
+            this._hyper.metrics
         )
         .then((consumer) => {
             this.consumer = consumer;
@@ -99,8 +101,8 @@ class BaseExecutor {
         try {
             return JSON.parse(payload);
         } catch (e) {
-            this.log(`error/${this.rule.name}`, e);
-            this.hyper.post({
+            this._logger.log(`error/parse`, e);
+            this._hyper.post({
                 uri: new URI('/sys/queue/events'),
                 body: [ this._constructErrorMessage(e, payload) ]
             });
@@ -119,7 +121,7 @@ class BaseExecutor {
             messages.forEach((msg) => {
                 const message = this._safeParse(msg.value.toString('utf8'));
 
-                this.hyper.metrics.increment(
+                this._hyper.metrics.increment(
                     `${this.statName(message.meta.topic)}_dequeue`,
                     1,
                     0.1);
@@ -155,7 +157,7 @@ class BaseExecutor {
                     // We're reading to fast, nothing is there, slow down a little bit
                     return P.delay(100);
                 default:
-                    this.log(`error/consumer/${this.rule.name}`, e);
+                    this._logger.log(`error/consumer`, e);
                     if (e.code === kafka.CODES.ERRORS.ERR__STATE) {
                         // KafkaConsumer is disconnected or entered error state.
                         // Give it some time to reconnect before the new attempt
@@ -186,7 +188,7 @@ class BaseExecutor {
         }
         return P.all(this.rule.getRateLimiterTypes().map((type) => {
             const key = this.rule.getLimiterKey(type, expander);
-            return this.hyper.get({
+            return this._hyper.get({
                 uri: new URI(`/sys/limit/${type}/${key}`)
             });
         }))
@@ -198,12 +200,12 @@ class BaseExecutor {
         // Will throw if any of the limiters failed,
         // the error message will say which one is failed.
         .catch({ status: 429 }, (e) => {
-            this.log('error/ratelimit', () => ({
+            this._logger.log('error/ratelimit', () => ({
                 msg: 'Rate-limited message processing',
-                rule_name: this.rule.name,
                 limiter: e.body.message,
                 limiter_key: e.body.key,
-                event_str: utils.stringify(expander.message)
+                event_str: utils.stringify(expander.message),
+                topic: expander.message.meta.topic
             }));
             return true;
         });
@@ -219,7 +221,7 @@ class BaseExecutor {
 
             if (status >= 500) {
                 const limiterKey = this.rule.getLimiterKey(type, expander);
-                return this.hyper.post({
+                return this._hyper.post({
                     uri: new URI(`/sys/limit/${type}/${limiterKey}`)
                 }).catch({ status: 429 }, () => {
                     // No need to react here, we'll reject the next message
@@ -234,7 +236,7 @@ class BaseExecutor {
         this._pendingMsgs.delete(finishedMsg.offset);
 
         if (this.options.test_mode) {
-            this.log('trace/commit', 'Running in TEST MODE; Offset commits disabled');
+            this._logger.log('trace/commit', 'Running in TEST MODE; Offset commits disabled');
             return;
         }
 
@@ -252,7 +254,7 @@ class BaseExecutor {
                 }
                 return this.consumer.commitMessageAsync(committing)
                 .catch((e) => {
-                    this.log(`error/commit/${this.rule.name}`, () => ({
+                    this._logger.log(`error/commit`, () => ({
                         msg: 'Commit failed',
                         offset: committing.offset,
                         raw_event: committing.value.toString(),
@@ -267,18 +269,22 @@ class BaseExecutor {
     /** Private methods */
 
     _test(event) {
+        const logger = this._logger.child({
+            topic: event.meta.topic
+        });
         try {
             const optionIndex = this.rule.test(event);
             if (optionIndex === -1) {
                 // no match, drop the message
-                this.log(`debug/${this.rule.name}`, () => ({
+                logger.log(`debug/drop_message`, () => ({
                     msg: 'Dropping event message',
-                    event_str: utils.stringify(event)
+                    event_str: utils.stringify(event),
+                    topic: event.meta.topic
                 }));
             }
             return optionIndex;
         } catch (e) {
-            this.log(`error/${this.rule.name}`, e);
+            logger.log(`error/test`, e);
             return -1;
         }
     }
@@ -290,25 +296,25 @@ class BaseExecutor {
                 event_str: utils.stringify(event),
                 request: {
                     uri: `${request.uri}`,
-                    headers: request.headers
+                    headers: request.headers,
+                    // Don't include the full body in the log
+                    body: request.body && utils.stringify(request.body).substr(0, 1024)
                 },
                 response: {
                     status: res.status,
                     headers: res.headers,
-                    body: utils.stringify(request.body).substr(0, 1024)
-                }
+                },
+                topic: event.meta.topic
             };
-            // Don't include the full body in the log
             if (res.status >= 400) {
                 log.response.body = BaseExecutor.decodeError(res).body;
             }
             return log;
         };
-        this.hyper.log('trace/sample', sampleLog);
+        this._logger.log('trace/sample', sampleLog);
     }
 
     _exec(origEvent, handler, statDelayStartTime, retryEvent) {
-        const rule = this.rule;
         const startTime = Date.now();
 
         const expander = {
@@ -326,7 +332,7 @@ class BaseExecutor {
                     // Not ready to execute yet - delay for some time and put back to the queue
                     return P.delay(20000)
                     .then(() => {
-                        return this.hyper.post({
+                        return this._hyper.post({
                             uri: new URI('/sys/queue/events'),
                             body: [ origEvent ]
                         });
@@ -339,35 +345,39 @@ class BaseExecutor {
         }
 
         if (handler.sampler && !handler.sampler.accept(expander)) {
-            this.log(`trace/${rule.name}`, () => ({
+            this._logger.log(`trace/discard`, () => ({
                 msg: 'Disregarding event; Filtered by sampler',
-                event: utils.stringify(origEvent)
+                event_str: utils.stringify(origEvent),
+                topic: origEvent.meta.topic
             }));
             return P.resolve({ status: 200 });
         }
 
         if (this.rule.shouldAbandon(origEvent)) {
-            this.log('trace/abandon', {
-                message: 'Event was abandoned',
+            this._logger.log('trace/abandon', {
+                msg: 'Event was abandoned',
                 event_str: utils.stringify(origEvent),
+                topic: origEvent.meta.topic
             });
             return P.resolve({ status: 200 });
         }
 
-        this.log(`trace/${rule.name}`, () => ({
+        this._logger.log(`trace/receive`, () => ({
             msg: 'Event message received',
-            event_str: utils.stringify(origEvent) }));
+            event_str: utils.stringify(origEvent),
+            topic: origEvent.meta.topic
+        }));
 
         // Latency from the event (if it's a retry - an original event)
         // creation time to execution time
-        this.hyper.metrics.endTiming([`${this.statName(origEvent.meta.topic)}_delay`],
+        this._hyper.metrics.endTiming([`${this.statName(origEvent.meta.topic)}_delay`],
             statDelayStartTime || new Date(origEvent.meta.dt));
 
         // This metric doesn't make much sense for retries
         if (origEvent.root_event && !retryEvent) {
             // Latency from the beginning of the recursive event chain
             // to the event execution
-            this.hyper.metrics.endTiming([`${this.statName(origEvent.meta.topic)}_totaldelay`],
+            this._hyper.metrics.endTiming([`${this.statName(origEvent.meta.topic)}_totaldelay`],
                 new Date(origEvent.root_event.dt));
         }
 
@@ -375,10 +385,10 @@ class BaseExecutor {
             if (res.status === 301) {
                 // As we don't follow redirects, and we must use normalized titles,
                 // receiving 301 indicates some error. Log a warning.
-                this.log(`warn/${this.rule.name}`, () => ({
+                this._logger.log(`warn/redirect`, () => ({
                     message: '301 redirect received, used a non-normalized title',
-                    rule: this.rule.name,
-                    event_str: utils.stringify(origEvent)
+                    event_str: utils.stringify(origEvent),
+                    topic: origEvent.meta.topic
                 }));
             }
         };
@@ -399,7 +409,7 @@ class BaseExecutor {
                         'x-request-id': origEvent.meta.request_id,
                         'x-triggered-by': utils.triggeredBy(retryEvent || origEvent)
                     });
-                    return this.hyper.request(request)
+                    return this._hyper.request(request)
                     .tap(redirectCheck)
                     .catch((e) => {
                         if (this.rule.shouldIgnoreError(BaseExecutor.decodeError(e))) {
@@ -412,7 +422,7 @@ class BaseExecutor {
                 })
                 .tap(() => this._updateLimiters(expander, 200))
                 .tapCatch(e => this._updateLimiters(expander, e.status))
-                .finally(() => this.hyper.metrics.endTiming(
+                .finally(() => this._hyper.metrics.endTiming(
                     [`${this.statName(origEvent.meta.topic)}_exec`],
                     startTime)
                 );
@@ -421,15 +431,15 @@ class BaseExecutor {
     }
 
     retryTopicName(topic) {
-        return `${this.hyper.config.service_name}.retry.${topic}`;
+        return `${this._hyper.config.service_name}.retry.${topic}`;
     }
 
     emitterId() {
-        return `${this.hyper.config.service_name}#${this.rule.name}`;
+        return `${this._hyper.config.service_name}#${this.rule.name}`;
     }
 
     _errorTopicName() {
-        return `${this.hyper.config.service_name}.error`;
+        return `${this._hyper.config.service_name}.error`;
     }
 
     _constructRetryMessage(event, errorRes, retriesLeft, retryEvent) {
@@ -465,13 +475,14 @@ class BaseExecutor {
      */
     _isLimitExceeded(message, e) {
         if (message.retries_left <= 0) {
-            this.log(`warn/${this.rule.name}`, () => ({
+            this._logger.log(`warn/retry_count`, () => ({
                 message: 'Retry count exceeded',
                 event_str: utils.stringify(message),
                 status: e.status,
                 page: message.meta.uri,
                 description: e.message,
-                stack: e.stack
+                stack: e.stack,
+                topic: message.meta.topic
             }));
             return true;
         }
@@ -479,7 +490,7 @@ class BaseExecutor {
     }
 
     _catch(message, retryMessage, e) {
-        const reportError = () => this.hyper.post({
+        const reportError = () => this._hyper.post({
             uri: new URI('/sys/queue/events'),
             body: [this._constructErrorMessage(e, message)]
         });
@@ -487,11 +498,12 @@ class BaseExecutor {
         if (e.constructor.name !== 'HTTPError') {
             // We've got an error, but it's not from the update request, it's
             // some bug in change-prop. Log and send a fatal error message.
-            this.hyper.log(`fatal/${this.rule.name}`, () => ({
-                message: `Internal error in ${this.hyper.config.service_name}`,
+            this._logger.log(`fatal/internal_error`, () => ({
+                message: `Internal error in ${this._hyper.config.service_name}`,
                 description: `${e}`,
                 stack: e.stack,
-                event_str: utils.stringify(message)
+                event_str: utils.stringify(message),
+                topic: message.meta.topic
             }));
             return reportError();
         }
@@ -499,7 +511,7 @@ class BaseExecutor {
         if (!this.rule.shouldIgnoreError(e)) {
             if (this.rule.shouldRetry(e)
                 && !this._isLimitExceeded(retryMessage, e)) {
-                return this.hyper.post({
+                return this._hyper.post({
                     uri: new URI('/sys/queue/events'),
                     body: [ retryMessage ]
                 });

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -83,9 +83,9 @@ class GuaranteedProducer extends kafka.Producer {
 }
 
 class AutopollingProducer extends kafka.Producer {
-    constructor(config, topicConfig, log) {
+    constructor(config, topicConfig, logger) {
         super(config, topicConfig);
-        this.on('event.error', e => log('error/producer', {
+        this.on('event.error', e => logger.log('error/producer', {
             msg: 'Producer error', e
         }));
     }
@@ -264,12 +264,12 @@ class KafkaFactory {
         .then(consumer => new MetadataWatch(consumer, this.consumeDC)._setup());
     }
 
-    _createProducerOfClass(ProducerClass, log) {
+    _createProducerOfClass(ProducerClass, logger) {
         return new P((resolve, reject) => {
             const producer = new ProducerClass(
                 this._producerConf,
                 this._producerTopicConf,
-                log || (() => {})
+                logger
             );
             producer.once('event.error', reject);
             producer.connect(undefined, (err) => {
@@ -282,12 +282,12 @@ class KafkaFactory {
 
     }
 
-    createProducer(log) {
-        return this._createProducerOfClass(AutopollingProducer, log);
+    createProducer(logger) {
+        return this._createProducerOfClass(AutopollingProducer, logger);
     }
 
-    createGuaranteedProducer(log) {
-        return this._createProducerOfClass(GuaranteedProducer, log);
+    createGuaranteedProducer(logger) {
+        return this._createProducerOfClass(GuaranteedProducer, logger);
     }
 }
 module.exports = KafkaFactory;

--- a/lib/mixins.js
+++ b/lib/mixins.js
@@ -29,7 +29,7 @@ const Redis = superclass => class extends superclass {
         this._redis.on('error', (e) => {
             // If we can't connect to redis - don't worry and don't fail,
             // just log it and ignore.
-            options.log('error/redis', e);
+            options.logger.log('error/redis', e);
         });
         HyperSwitch.lifecycle.on('close', () => this._redis.quit());
     }

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -14,7 +14,7 @@ class RetryExecutor extends BaseExecutor {
     }
 
     statName(topic) {
-        return this.hyper.metrics.normalizeName(
+        return this._hyper.metrics.normalizeName(
             `${this.rule.name}-${topic.replace(/\./g, '_')}_retry`);
     }
 

--- a/lib/rule_executor.js
+++ b/lib/rule_executor.js
@@ -12,7 +12,7 @@ class RuleExecutor extends BaseExecutor {
     }
 
     statName(topic) {
-        return this.hyper.metrics.normalizeName(
+        return this._hyper.metrics.normalizeName(
             `${this.rule.name}-${topic.replace(/\./g, '_')}`);
     }
 
@@ -49,7 +49,7 @@ class RuleExecutor extends BaseExecutor {
         } else {
             dedupeKey = `${this.rule.name}-${expander.message.meta.topic}`;
         }
-        return this.hyper.post({
+        return this._hyper.post({
             uri: new URI(`/sys/dedupe/${dedupeKey}`),
             body: expander.message
         })

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -10,14 +10,14 @@ class BasicSubscription {
     constructor(options, kafkaFactory, hyper, ruleName, ruleSpec) {
         this._kafkaFactory = kafkaFactory;
         this._options = options;
-        this._log = this._options.log || (() => {});
+        this._hyper = hyper;
         ruleSpec.sample =  ruleSpec.sample || options.sample;
         this._rule = new Rule(ruleName, ruleSpec);
         this._subscribed = false;
         this._executor = new RuleExecutor(this._rule, this._kafkaFactory,
-            hyper, this._log, this._options);
+            hyper, this._options);
         this._retryExecutor = new RetryExecutor(this._rule, this._kafkaFactory,
-            hyper, this._log, this._options);
+            hyper, this._options);
     }
 
     subscribe() {
@@ -25,7 +25,7 @@ class BasicSubscription {
             throw new Error('Already subscribed!');
         }
 
-        this._log('info/subscription', {
+        this._hyper.logger.log('info/subscription', {
             message: 'Subscribing based on basic topics',
             rule: this._rule.name,
             topics: this._rule.topics
@@ -49,7 +49,6 @@ class RegexTopicSubscription {
     constructor(options, kafkaFactory, hyper, ruleName, ruleSpec, metadataWatch) {
         this._kafkaFactory = kafkaFactory;
         this._options = options;
-        this._log = this._options.log || (() => {});
         this._hyper = hyper;
         this._ruleName = ruleName;
         this._ruleSpec = ruleSpec;
@@ -71,7 +70,7 @@ class RegexTopicSubscription {
             }
         });
         // Ignore the emitted errors - in 10 seconds it will retry
-        this._metadataWatch.on('error', e => this._log('error/metadata_refresh', e));
+        this._metadataWatch.on('error', e => this._hyper.logger.log('error/metadata_refresh', e));
 
         this._subscribed = false;
         this._executors = [];
@@ -101,18 +100,18 @@ class RegexTopicSubscription {
         const topicRule = Rule.newWithTopicNames(this._ruleName,
             this._ruleSpec, this._filteredTopics);
 
-        this._log('info/subscription', {
+        this._hyper.logger.log('info/subscription', {
             message: 'Subscribing based on regex',
             rule: this._ruleName,
             topics: topicRule.topics
         });
 
         const executor = new RuleExecutor(topicRule, this._kafkaFactory,
-            this._hyper, this._log, this._options);
+            this._hyper, this._options);
         this._executors.push(executor);
 
         const retryExecutor = new RetryExecutor(topicRule, this._kafkaFactory,
-            this._hyper, this._log, this._options);
+            this._hyper, this._options);
         this._executors.push(retryExecutor);
 
         return P.join(executor.subscribe(), retryExecutor.subscribe())

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "bluebird": "^3.5.1",
     "cassandra-uuid": "^0.0.2",
     "extend": "^3.0.1",
-    "hyperswitch": "^0.9.6",
+    "hyperswitch": "^0.10.0",
     "service-runner": "^2.6.1",
     "json-stable-stringify": "^1.0.1",
     "htcp-purge": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "bluebird": "^3.5.1",
     "cassandra-uuid": "^0.0.2",
     "extend": "^3.0.1",
-    "hyperswitch": "^0.10.0",
+    "hyperswitch": "^0.10.1",
     "service-runner": "^2.6.1",
     "json-stable-stringify": "^1.0.1",
     "htcp-purge": "^0.3.0",

--- a/sys/deduplicator.js
+++ b/sys/deduplicator.js
@@ -11,7 +11,6 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
         super(options);
 
         this._options = options || {};
-        this._log = this._options.log || (() => {});
         this._expire_timeout = options.window || 86400;
         this._prefix = this._options.redis_prefix || 'CP';
     }
@@ -39,7 +38,7 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
                 return NOT_DUPLICATE;
             }
             hyper.metrics.increment(`${name}_dedupe`);
-            hyper.log('trace/dedupe', () => ({
+            hyper.logger.log('trace/dedupe', () => ({
                 message: 'Event was deduplicated based on id',
                 event_str: utils.stringify(message),
             }));
@@ -60,7 +59,7 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
                 if (previousExecutionTime
                         && new Date(previousExecutionTime) > new Date(message.meta.dt)) {
                     hyper.metrics.increment(`${name}_dedupe`);
-                    hyper.log('trace/dedupe', () => ({
+                    hyper.logger.log('trace/dedupe', () => ({
                         message: 'Event was deduplicated based on sha1',
                         event_str: utils.stringify(message),
                         newer_dt: previousExecutionTime
@@ -74,7 +73,7 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
                         && message.root_event
                         && new Date(previousExecutionTime) > new Date(message.root_event.dt)) {
                     hyper.metrics.increment(`${name}_dedupe`);
-                    hyper.log('trace/dedupe', () => ({
+                    hyper.logger.log('trace/dedupe', () => ({
                         message: 'Event was deduplicated based on sha1 and root_event dt',
                         event_str: utils.stringify(message),
                         newer_dt: previousExecutionTime
@@ -102,7 +101,7 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
                 if (oldEventTimestamp
                         && new Date(oldEventTimestamp) > new Date(message.root_event.dt)) {
                     hyper.metrics.increment(`${name}_dedupe`);
-                    hyper.log('trace/dedupe', () => ({
+                    hyper.logger.log('trace/dedupe', () => ({
                         message: 'Event was deduplicated based on root event',
                         event_str: utils.stringify(message),
                         signature: message.root_event.signature,
@@ -116,7 +115,7 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
             });
         })
         .catch((e) => {
-            this._log('error/dedupe', {
+            hyper.logger.log('error/dedupe', {
                 message: 'Error during deduplication',
                 error: e
             });

--- a/sys/dep_updates.js
+++ b/sys/dep_updates.js
@@ -167,7 +167,6 @@ function _sendResourceChanges(hyper, items, originalEvent, tags, topicName) {
 class DependencyProcessor {
     constructor(options) {
         this.options = options;
-        this.log = options.log || (() => { });
         this.siteInfoCache = {};
         this.backLinksRequest = createBackLinksTemplate(options);
         this.imageLinksRequest = createImageUsageTemplate(options);
@@ -232,7 +231,7 @@ class DependencyProcessor {
             }
 
             if (res.body && res.body.error) {
-                this.log('warn/wikidata_description', () => ({
+                hyper.logger.log('warn/wikidata_description', () => ({
                     msg: 'Could not extract items',
                     event_str: utils.stringify(context.message),
                     error: res.body.error
@@ -290,7 +289,7 @@ class DependencyProcessor {
                 };
             })
             .catch((e) => {
-                hyper.log('error/site_info', e);
+                hyper.logger.log('error/site_info', e);
                 delete this.siteInfoCache[domain];
                 throw e;
             });

--- a/sys/kafka.js
+++ b/sys/kafka.js
@@ -18,7 +18,6 @@ const RuleSubscriber = require('../lib/rule_subscriber');
 class Kafka {
     constructor(options) {
         this.options = options;
-        this.log = options.log || (() => { });
         this.kafkaFactory = new KafkaFactory(options);
         this.staticRules = options.templates || {};
 
@@ -26,7 +25,7 @@ class Kafka {
     }
 
     setup(hyper) {
-        return this.kafkaFactory.createGuaranteedProducer(this.log)
+        return this.kafkaFactory.createGuaranteedProducer(hyper.logger)
         .then((producer) => {
             this.producer = producer;
             HyperSwitch.lifecycle.once('close', () => {
@@ -35,7 +34,7 @@ class Kafka {
             });
             return this._subscribeRules(hyper, this.staticRules);
         })
-        .tap(() => this.log('info/change-prop/init', 'Kafka Queue module initialised'));
+        .tap(() => hyper.logger.log('info/change-prop/init', 'Kafka Queue module initialised'));
     }
 
     _subscribeRules(hyper, rules) {
@@ -50,7 +49,7 @@ class Kafka {
 
     produce(hyper, req) {
         if (this.options.test_mode) {
-            this.log('trace/produce', 'Running in TEST MODE; Production disabled');
+            hyper.logger.log('trace/produce', 'Running in TEST MODE; Production disabled');
             return { status: 201 };
         }
 

--- a/sys/partitioner.js
+++ b/sys/partitioner.js
@@ -3,7 +3,6 @@
 class Partitioner {
     constructor(options) {
         this._options = options || {};
-        this._log = this._options.log || (() => {});
 
         if (!options.partition_topic_name) {
             throw new Error('No partition_topic_name was provided to the partitioner');

--- a/sys/purge.js
+++ b/sys/purge.js
@@ -36,7 +36,7 @@ class PurgeService {
 
         return this.purger.purge(req.body.map((event) => {
             if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri)) {
-                hyper.log('error/events/purge', () => ({
+                hyper.logger.log('error/events/purge', () => ({
                     message: 'Invalid event URI',
                     event_str: utils.stringify(event)
                 }));

--- a/sys/rate_limiter.js
+++ b/sys/rate_limiter.js
@@ -11,7 +11,6 @@ class RateLimiter extends mixins.mix(Object).with(mixins.Redis) {
         super(options);
 
         this._options = options;
-        this._log = this._options.log || (() => {});
 
         this._LIMITERS = new Map();
         Object.keys(this._options.limiters).forEach((type) => {
@@ -36,7 +35,7 @@ class RateLimiter extends mixins.mix(Object).with(mixins.Redis) {
         const limiter = this._LIMITERS.get(type);
 
         if (!limiter) {
-            hyper.log('warn/ratelimit', {
+            hyper.logger.log('warn/ratelimit', {
                 msg: 'Unconfigured rate-limiter is used',
                 limiter_type: type
             });
@@ -48,7 +47,7 @@ class RateLimiter extends mixins.mix(Object).with(mixins.Redis) {
         return new P((resolve, reject) => {
             limiter[fun](key, (err, isRateLimited) => {
                 if (err) {
-                    hyper.log('error/ratelimit', err);
+                    hyper.logger.log('error/ratelimit', err);
                     hyper.metrics.endTiming(`ratelimit.${fun}.err`, startTime);
                     // In case we've got problems with limiting just allow everything
                     return resolve({ status: 200 });

--- a/test/feature/job_rules.js
+++ b/test/feature/job_rules.js
@@ -17,7 +17,7 @@ describe('JobQueue rules', function() {
         // Setting up might take some tome, so disable the timeout
         this.timeout(50000);
         return changeProp.start()
-        .then(() => common.factory.createProducer(console.log.bind(console)))
+        .then(() => common.factory.createProducer({ log: console.log.bind(console) }))
         .then(result => producer = result);
     });
 

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -29,7 +29,7 @@ describe('Basic rule management', function() {
         .then((res) => retrySchema = yaml.safeLoad(res.body))
         .then(() => preq.get({ uri: 'https://raw.githubusercontent.com/wikimedia/mediawiki-event-schemas/master/jsonschema/error/1.yaml' }))
         .then((res) => errorSchema = yaml.safeLoad(res.body))
-        .then(() => common.factory.createProducer(console.log.bind(console)))
+        .then(() => common.factory.createProducer({ log: console.log.bind(console) }))
         .then((result) => producer = result);
     });
 

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -35,7 +35,7 @@ describe('RESTBase update rules', function() {
             });
         })
         .then((res) => siteInfoResponse = res.body)
-        .then(() => common.factory.createProducer(console.log.bind(console)))
+        .then(() => common.factory.createProducer({ log: console.log.bind(console) }))
         .then((result) => producer = result);
     });
 


### PR DESCRIPTION
1. Stop using hyper.log and use the logger instead.
2. Include the rule name in all the logs
3. Include the topic name in the log whenever possible
4. Fix up some logging bugs.
5. Stop including the rule name in the log level, instead, make the log level descriptive on what's happened and include the rule name as a separate property.

Depends on the hyperswitch 0.10 changes
cc @wikimedia/services 