### PR TITLE
Resubscribe to proper list of topics once the list changes

### DIFF
--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -67,7 +67,7 @@ class RegexTopicSubscription {
             const newFilteredTopics = this._filterTopics(topics);
             if (stringify(newFilteredTopics) !== stringify(this._filteredTopics)) {
                 this.unsubscribe();
-                this._subscribeTopics(topics);
+                this._subscribeTopics(newFilteredTopics);
             }
         });
         // Ignore the emitted errors - in 10 seconds it will retry


### PR DESCRIPTION
I think this obvious bug doesn't need explanation - when the list of existing topics change we subscribe to ALL new topics, not just those we've filtered for, creating a gazillion of retry.retry.retry topics. When retry.retry topics are created we notice the topic list changed again, so it repeats.

cc @wikimedia/services 
@ottomata - this is the source of a problem we've seen yesterday.
@d00rman - this is why CP and CP4JQ are stopped in prod, but even if you deploy this before I wake up, the kafka topics are needed a cleanup or kafka will probably not even startup. But production can potentially blow up because of this, so if you have time to deploy this in prod better we do this ASAP