### PR TITLE
Use the latest service-runner v2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cassandra-uuid": "^0.0.2",
     "extend": "^3.0.1",
     "hyperswitch": "^0.9.6",
-    "service-runner": "^2.5.2",
+    "service-runner": "^2.6.1",
     "json-stable-stringify": "^1.0.1",
     "htcp-purge": "^0.3.0",
     "mediawiki-title": "^0.6.5",


### PR DESCRIPTION
Require the latest version of service-runner, which allows us to start
multiple workers at the same time.