### PR TITLE
Allow protocol version negotiation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+      - oracle-java8-set-default
 
 before_script:
 - npm run install-kafka

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ node_js:
   - "8"
 
 env:
-  - KAFKA_HOME=../kafka KAFKA_VERSION=0.9.0.1 CXX=g++-4.8
-  - KAFKA_HOME=../kafka KAFKA_VERSION=0.10.1.0 CXX=g++-4.8
+  - KAFKA_HOME=../kafka KAFKA_VERSION=1.1.0 CXX=g++-4.8
 
 services:
   - redis-server

--- a/lib/kafka_factory.js
+++ b/lib/kafka_factory.js
@@ -7,9 +7,7 @@ const EventEmitter = require('events').EventEmitter;
 const CONSUMER_DEFAULTS = {
     // We don't want the driver to commit automatically the offset of just read message,
     // we will handle offsets manually.
-    'enable.auto.commit': 'false',
-    'api.version.request': 'false',
-    'broker.version.fallback': '0.9.0'
+    'enable.auto.commit': 'false'
 };
 
 const CONSUMER_TOPIC_DEFAULTS = {
@@ -19,9 +17,7 @@ const CONSUMER_TOPIC_DEFAULTS = {
 };
 
 const PRODUCER_DEFAULTS = {
-    dr_cb: true,
-    'api.version.request': 'false',
-    'broker.version.fallback': '0.9.0'
+    dr_cb: true
 };
 
 const PRODUCER_TOPIC_DEFAULTS = {


### PR DESCRIPTION
As a part of upgrade of the kafka brokers from 0.9 to 1.1.0
we need to allow the clients to use a new feature of API
version negotiation so that change-prop actually use the
right protocol talking to the brokers.

Also, update CI configuration to test agains 1.1.0 broker version.

Bug: T167039

cc @ottomata @wikimedia/services 