### PR TITLE
Log events that are processed but very old

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -380,10 +380,22 @@ class BaseExecutor {
             topic: origEvent.meta.topic
         }));
 
+        const metricStartTime = statDelayStartTime || new Date(origEvent.meta.dt);
+        if (Date.now() - metricStartTime > 86400000) {
+            // Log a warning for jobs that has more then 1 day normal delay
+            // Note: this is not the root-event delay, just normal delay.
+            this._logger.log('warn/oldevent', () => ({
+                msg: 'Old event processed',
+                event_str: utils.stringify(origEvent),
+                topic: origEvent.meta.topic
+            }));
+        }
         // Latency from the event (if it's a retry - an original event)
         // creation time to execution time
-        this._hyper.metrics.endTiming([`${this.statName(origEvent.meta.topic)}_delay`],
-            statDelayStartTime || new Date(origEvent.meta.dt));
+        this._hyper.metrics.endTiming(
+            [`${this.statName(origEvent.meta.topic)}_delay`],
+            metricStartTime
+        );
 
         // This metric doesn't make much sense for retries
         if (origEvent.root_event && !retryEvent) {


### PR DESCRIPTION
Right now the metric weirdly show that we process a TranslateDeleteJob that's more than 2 days old from time to time. To figure out why - log when that happens.

cc @wikimedia/services 