### PR TITLE
Purge definitions endpoint on mediawiki purges.

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -182,37 +182,71 @@ spec: &spec
               # RESTBase update jobs
               mw_purge:
                 topic: resource_change
-                match:
-                  meta:
-                    uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
-                  tags:
-                    - purge
                 limiters:
                   blacklist: 'html:{message.meta.uri}'
-                exec:
-                  - method: get
-                    # This even comes directly from MediaWiki, so title is encoded in MW-specific way.
-                    # Re-encode the title in standard `encodeURIComponent` encoding.
-                    uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{decode(match.meta.uri.title)}'
-                    headers:
-                      cache-control: no-cache
-                      if-unmodified-since: '{{date(message.meta.dt)}}'
-                    query:
-                      redirect: false
-                    # The HTML might not change but sometimes editors use a purge to drop incorrectly rendered summary/MCS
-                    # content, so let's purge them as well just in case. The rate is low.
-                  - method: get
-                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{decode(match.meta.uri.title)}'
-                    headers:
-                      cache-control: no-cache
-                    query:
-                      redirect: false
-                  - method: get
-                    uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{decode(match.meta.uri.title)}'
-                    headers:
-                      cache-control: no-cache
-                    query:
-                      redirect: false
+                cases:
+                  - match:
+                      meta:
+                        uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
+                      tags:
+                        - purge
+                    match_not:
+                      meta:
+                        domain: '/.*\.wiktionary.org$/'
+                    exec:
+                      - method: get
+                        # This even comes directly from MediaWiki, so title is encoded in MW-specific way.
+                        # Re-encode the title in standard `encodeURIComponent` encoding.
+                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{decode(match.meta.uri.title)}'
+                        headers:
+                          cache-control: no-cache
+                          if-unmodified-since: '{{date(message.meta.dt)}}'
+                        query:
+                          redirect: false
+                        # The HTML might not change but sometimes editors use a purge to drop incorrectly rendered summary/MCS
+                        # content, so let's purge them as well just in case. The rate is low.
+                      - method: get
+                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/summary/{decode(match.meta.uri.title)}'
+                        headers:
+                          cache-control: no-cache
+                        query:
+                          redirect: false
+                      - method: get
+                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{decode(match.meta.uri.title)}'
+                        headers:
+                          cache-control: no-cache
+                        query:
+                          redirect: false
+                  - match:
+                      meta:
+                        uri: '/^(?<proto>https?):\/\/[^\/]+\/wiki\/(?<title>.+)$/'
+                        domain: '/.*\.wiktionary.org$/'
+                      tags:
+                        - purge
+                    exec:
+                      - method: get
+                        # This even comes directly from MediaWiki, so title is encoded in MW-specific way.
+                        # Re-encode the title in standard `encodeURIComponent` encoding.
+                        uri: '{{match.meta.uri.proto}}://{{message.meta.domain}}/api/rest_v1/page/html/{decode(match.meta.uri.title)}'
+                        headers:
+                          cache-control: no-cache
+                          if-unmodified-since: '{{date(message.meta.dt)}}'
+                        query:
+                          redirect: false
+                        # The HTML might not change but sometimes editors use a purge to drop incorrectly rendered summary/MCS
+                        # content, so let's purge them as well just in case. The rate is low.
+                      - method: get
+                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/definition/{decode(match.meta.uri.title)}'
+                        headers:
+                          cache-control: no-cache
+                        query:
+                          redirect: false
+                      - method: get
+                        uri: 'https://{{message.meta.domain}}/api/rest_v1/page/mobile-sections/{decode(match.meta.uri.title)}'
+                        headers:
+                          cache-control: no-cache
+                        query:
+                          redirect: false
 
               null_edit:
                 topic: resource_change


### PR DESCRIPTION
Bug: https://phabricator.wikimedia.org/T192157
cc @wikimedia/services @berndsi