### PR TITLE
Create metrics to track the actual concurrent job executions.

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -481,6 +481,8 @@ class BaseExecutor {
                 if (messageDeduped) {
                     return { status: 200 };
                 }
+                this._hyper.metrics.increment(
+                    `${this.statName(origEvent.meta.topic)}_concurrency`);
                 return P.each(handler.exec, (tpl, index) => {
                     const request = tpl.expand(expander);
                     request.headers = Object.assign(request.headers, {
@@ -500,10 +502,13 @@ class BaseExecutor {
                 })
                 .tap(() => this._updateLimiters(expander, 200))
                 .tapCatch(e => this._updateLimiters(expander, e.status))
-                .finally(() => this._hyper.metrics.endTiming(
-                    [`${this.statName(origEvent.meta.topic)}_exec`],
-                    startTime)
-                );
+                .finally(() => {
+                    this._hyper.metrics.decrement(
+                        `${this.statName(origEvent.meta.topic)}_concurrency`);
+                    this._hyper.metrics.endTiming(
+                        [`${this.statName(origEvent.meta.topic)}_exec`],
+                        startTime);
+                });
             });
         });
     }


### PR DESCRIPTION
The number of concurrent jobs is not the same as the rate
of execution. When the jobs become slow, we can actually
pile up more concurrent jobs and so more DB connections
and HHVM threads even if the execution rate goes down.

This metric will allow us to see if that's indeed happening.

Bug: https://phabricator.wikimedia.org/T202107