### PR TITLE
Make the queue sized report stats once a second

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -104,6 +104,7 @@ class BaseExecutor {
         this._commitTimeout = null;
         // In order ti filter out the pending messages faster make them offset->msg map
         this._pendingMsgs = new Set();
+        this._pendingMsgsCountsReporter = new utils.CountsReporter(hyper.metrics);
         this._pendingCommits = new Map();
         this._consuming = false;
     }
@@ -481,7 +482,7 @@ class BaseExecutor {
                 if (messageDeduped) {
                     return { status: 200 };
                 }
-                this._hyper.metrics.increment(
+                this._pendingMsgsCountsReporter.increment(
                     `${this.statName(origEvent.meta.topic)}_concurrency`);
                 return P.each(handler.exec, (tpl, index) => {
                     const request = tpl.expand(expander);
@@ -503,7 +504,7 @@ class BaseExecutor {
                 .tap(() => this._updateLimiters(expander, 200))
                 .tapCatch(e => this._updateLimiters(expander, e.status))
                 .finally(() => {
-                    this._hyper.metrics.decrement(
+                    this._pendingMsgsCountsReporter.decrement(
                         `${this.statName(origEvent.meta.topic)}_concurrency`);
                     this._hyper.metrics.endTiming(
                         [`${this.statName(origEvent.meta.topic)}_exec`],
@@ -640,6 +641,7 @@ class BaseExecutor {
 
     close() {
         this.consumer.disconnect();
+        this._pendingMsgsCountsReporter.close();
     }
 
     static decodeError(e) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,4 +57,38 @@ utils.constructRegex = (list) => {
     return new RegExp(regex);
 };
 
+utils.CountsReporter = class CountsReporter {
+    constructor(metrics, interval = 1000) {
+        this._metrics = metrics;
+        this._counts = new Map();
+        this._reportInterval = setInterval(() => {
+            for (const metricKey of this._counts.keys()) {
+                this._metrics.gauge(metricKey, this._counts.get(metricKey));
+            }
+            this._counts.clear();
+        }, interval);
+    }
+
+    _addValue(key, value) {
+        if (this._counts.has(key)) {
+            this._counts.set(key, this._counts.get(key) + value);
+        } else {
+            this._counts.set(key, value);
+        }
+    }
+
+    increment(key) {
+        this._addValue(key, 1);
+    }
+
+    decrement(key) {
+        this._addValue(key, -1);
+    }
+
+    close() {
+        clearInterval(this._reportInterval);
+    }
+
+};
+
 module.exports = utils;


### PR DESCRIPTION
@d00rman was correct in #284 - we need to accumulate the stats locally - it's not only more efficient, just sending increment-decrement into statsd simply doesn't work.

cc @wikimedia/services 