### PR TITLE
Use timing for queue sizes as grafana is not gauges

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,7 +63,11 @@ utils.CountsReporter = class CountsReporter {
         this._counts = new Map();
         this._reportInterval = setInterval(() => {
             for (const metricKey of this._counts.keys()) {
-                this._metrics.gauge(metricKey, this._counts.get(metricKey));
+                // In reality this is a gauge, but Grafana is only capable
+                // of displaying gauges as a pie chart, not plot them over time
+                // in a graph, and that's the visualization we're looking for.
+                // As a workaround - use the `timing` method.
+                this._metrics.timing(metricKey, this._counts.get(metricKey));
             }
             this._counts.clear();
         }, interval);


### PR DESCRIPTION
Follow-up to #285 

cc @wikimedia/services 
