### PR TITLE
Clone the event in the partitioner.

### DIFF
--- a/sys/partitioner.js
+++ b/sys/partitioner.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const extend = require('extend');
+
 class Partitioner {
     constructor(options) {
         this._options = options || {};
@@ -39,8 +41,7 @@ class Partitioner {
         // the original event since that could mess up processing
         // in the executor regarding metrics, limiters, follow-up
         // executions etc.
-        event = Object.assign({}, event);
-        event.meta = Object.assign({}, event.meta);
+        event = extend(true, {}, event);
         event.meta.topic = this._options.partition_topic_name;
         return hyper.post({
             uri: `/sys/queue/events/${partition}`,


### PR DESCRIPTION
The partitioner actually modifies the original event
which messes up with higher level of execution - metrics,
logging, subsequent requests could be broken. In particular,
our metrics are reporting incorrect data because of this.

This will create some additional cpu/mem usage, but I think
that would be negligible.

cc @wikimedia/services 