### PR TITLE
Remove the concurrency metric

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -104,7 +104,6 @@ class BaseExecutor {
         this._commitTimeout = null;
         // In order ti filter out the pending messages faster make them offset->msg map
         this._pendingMsgs = new Set();
-        this._pendingMsgsCountsReporter = new utils.CountsReporter(hyper.metrics);
         this._pendingCommits = new Map();
         this._consuming = false;
     }
@@ -482,8 +481,6 @@ class BaseExecutor {
                 if (messageDeduped) {
                     return { status: 200 };
                 }
-                this._pendingMsgsCountsReporter.increment(
-                    `${this.statName(origEvent.meta.topic)}_concurrency`);
                 return P.each(handler.exec, (tpl, index) => {
                     const request = tpl.expand(expander);
                     request.headers = Object.assign(request.headers, {
@@ -503,13 +500,10 @@ class BaseExecutor {
                 })
                 .tap(() => this._updateLimiters(expander, 200))
                 .tapCatch(e => this._updateLimiters(expander, e.status))
-                .finally(() => {
-                    this._pendingMsgsCountsReporter.decrement(
-                        `${this.statName(origEvent.meta.topic)}_concurrency`);
-                    this._hyper.metrics.endTiming(
-                        [`${this.statName(origEvent.meta.topic)}_exec`],
-                        startTime);
-                });
+                .finally(() => this._hyper.metrics.endTiming(
+                    [`${this.statName(origEvent.meta.topic)}_exec`],
+                    startTime)
+                );
             });
         });
     }
@@ -641,7 +635,6 @@ class BaseExecutor {
 
     close() {
         this.consumer.disconnect();
-        this._pendingMsgsCountsReporter.close();
     }
 
     static decodeError(e) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,41 +57,4 @@ utils.constructRegex = (list) => {
     return new RegExp(regex);
 };
 
-utils.CountsReporter = class CountsReporter {
-    constructor(metrics, interval = 1000) {
-        this._metrics = metrics;
-        this._counts = new Map();
-        this._reportInterval = setInterval(() => {
-            for (const metricKey of this._counts.keys()) {
-                // In reality this is a gauge, but Grafana is only capable
-                // of displaying gauges as a pie chart, not plot them over time
-                // in a graph, and that's the visualization we're looking for.
-                // As a workaround - use the `timing` method.
-                this._metrics.timing(metricKey, this._counts.get(metricKey));
-            }
-        }, interval);
-    }
-
-    _addValue(key, value) {
-        if (this._counts.has(key)) {
-            this._counts.set(key, this._counts.get(key) + value);
-        } else {
-            this._counts.set(key, value);
-        }
-    }
-
-    increment(key) {
-        this._addValue(key, 1);
-    }
-
-    decrement(key) {
-        this._addValue(key, -1);
-    }
-
-    close() {
-        clearInterval(this._reportInterval);
-    }
-
-};
-
 module.exports = utils;


### PR DESCRIPTION
It's possible to get the same metric just by looking into the _exec metric, so remove this one.

cc @wikimedia/services 