### PR TITLE
Respect readonly mode

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -586,6 +586,18 @@ class BaseExecutor {
             return reportError();
         }
 
+        /*
+        JobQueue specific.
+        If the DB is in readonly mode, the `x-readonly` header will be set to true
+        by the job executor. In this case we ignore this retry attempt, cause it didn't
+        really fail for 'natural' reasons, rather it failed due to maintenance most likely.
+        Adding 1 attempt doesn't really increase the counter, as it was decremented before.
+         */
+        if (e.headers && e.headers['x-readonly']
+                && retryMessage.retries_left < this.rule.spec.retry_limit) {
+            retryMessage.retries_left += 1;
+        }
+
         if (!this.rule.shouldIgnoreError(e)) {
             this._logger.log('info/exec_error', () => ({
                 message: `Exec error in ${this._hyper.config.service_name}`,

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -60,9 +60,20 @@ class RetryExecutor extends BaseExecutor {
         .then(() => this._exec(message.original_event, handler, new Date(message.meta.dt), message))
         .catch((e) => {
             e = BaseExecutor.decodeError(e);
+
             const retryMessage = this._constructRetryMessage(message.original_event,
                 e, message.retries_left - 1, message);
-            return this._catch(message, retryMessage, e);
+            /*
+            JobQueue specific.
+            If the DB is in readonly mode, the `x-readonly` header will be set to true
+            by the job executor. In that case we want to delay a retry even more to avoid
+            unnecessary load on the job runners.
+             */
+            let optionalDelay = P.resolve();
+            if (e.headers && e.headers['x-readonly']) {
+                optionalDelay = P.delay(Math.ceil(30000 + Math.random() * 30000));
+            }
+            return optionalDelay.then(() => this._catch(message, retryMessage, e));
         });
     }
 


### PR DESCRIPTION
We do 2 very empirical things here:
1. We indefinitely retry the messages until we get out of readonly mode, and preserve the remaining number of retries that were before readonly was detected - thus read-only errors are ignored in the total retry limit count.
2. We add some random artificial delay to pace down retries even more as if we retry indefinitely the backlog of retries will keep growing and growing until the readonly mode is over. With additional pacing, this effect will be dramatically decreased.

cc @wikimedia/services @lavagetto 