### PR TITLE
Added performer to the revision-scores event

### DIFF
--- a/sys/ores_updates.js
+++ b/sys/ores_updates.js
@@ -41,6 +41,7 @@ class OresProcessor {
                 page_id: message.page_id,
                 page_title: message.page_title,
                 page_namespace: message.page_namespace,
+                performer: message.performer,
                 rev_id: message.rev_id,
                 rev_parent_id: message.rev_parent_id,
                 rev_timestamp: message.rev_timestamp

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -199,6 +199,8 @@ common.events = {
             rev_timestamp: new Date().toISOString(),
             rev_parent_id: 1233,
             performer: {
+                user_text: 'I am a user',
+                user_groups: [ 'I am a group' ],
                 user_is_bot: false
             }
         }


### PR DESCRIPTION
We have forgotten to add a performer property to the revision-score event.

cc @wikimedia/services @ottomata 