### PR TITLE
Replace `json-stable-stringify` with `fast-json-stable-stringify`

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 const HyperSwitch = require('hyperswitch');
 const Sampler = require('./sampler');
 const Template = HyperSwitch.Template;

--- a/lib/rule_subscriber.js
+++ b/lib/rule_subscriber.js
@@ -4,7 +4,7 @@ const RuleExecutor = require('./rule_executor');
 const RetryExecutor = require('./retry_executor');
 const Rule = require('./rule');
 const P = require('bluebird');
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 
 class BasicSubscription {
     constructor(options, kafkaFactory, hyper, ruleName, ruleSpec) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "extend": "^3.0.1",
     "hyperswitch": "^0.10.2",
     "service-runner": "^2.6.3",
-    "json-stable-stringify": "^1.0.1",
+    "fast-json-stable-stringify": "^2.0.0",
     "htcp-purge": "^0.3.0",
     "mediawiki-title": "^0.6.5",
     "murmur-32": "^0.1.0",


### PR DESCRIPTION
fast-json-stable-stringify is being used because it does not have any dependencies and has been shown to be faster than json-stable-stringify

Bug: [T210426](https://phabricator.wikimedia.org/T210426)