### PR TITLE
Fix copy-pasted comment in deduplicator

### DIFF
--- a/sys/deduplicator.js
+++ b/sys/deduplicator.js
@@ -46,8 +46,8 @@ class Deduplicator extends mixins.mix(Object).with(mixins.Redis) {
         })
         .then((individualDuplicate) => {
             if (individualDuplicate.body || !message.sha1) {
-                // If the message was sha1-deduped or if it has no root event info,
-                // don't use deduplication by the root event
+                // If the message was deduped based on its event ID or if it has no SHA-1 hash,
+                // don't try to deduplicate by SHA-1
                 return individualDuplicate;
             }
             const messageKey = `${this._prefix}_dedupe_${name}_${message.sha1}`;


### PR DESCRIPTION
The comment describing the early return case when a message was deduplicated based on its event ID was copy-pasted from the early return case where a message is deduplicated by its SHA-1 info hash. This change fixes the comment to avoid confusion.