### PR TITLE
Use openjdk in travis instead of oracle jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 before_script:
 - npm run install-kafka


### PR DESCRIPTION
The oracle-java8-set-default package is no longer available.