### PR TITLE
Switch revision-score event to eventgate.

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -15,7 +15,7 @@ spec: &spec
           options:
             ores_precache_uris:
               - 'https://ores.wikimedia.org/v3/precache'
-            eventbus_uri: 'https://eventbus.stubfortests.org/v1/events'
+            event_service_uri: 'https://eventgate.stubfortests.org/v1/events'
     /sys/limit:
       x-modules:
         - path: sys/rate_limiter.js

--- a/sys/ores_updates.js
+++ b/sys/ores_updates.js
@@ -7,10 +7,10 @@ class OresProcessor {
     constructor(options) {
         this._options = options;
         if (!options.ores_precache_uris || !Array.isArray(options.ores_precache_uris)) {
-            throw new Error('OresProcessor is miconfigured. ores_precache_uris is required');
+            throw new Error('OresProcessor is misconfigured. ores_precache_uris is required');
         }
-        if (!options.eventbus_uri) {
-            throw new Error('OresProcessor is miconfigured. eventbus_uri is required');
+        if (!options.event_service_uri) {
+            throw new Error('OresProcessor is misconfigured. event_service_uri is required');
         }
     }
 
@@ -29,8 +29,9 @@ class OresProcessor {
             }
             const now = new Date();
             const newMessage = {
+                $schema: '/mediawiki/revision/score/1.0.0',
                 meta: {
-                    topic: 'mediawiki.revision-score',
+                    stream: 'mediawiki.revision-score',
                     uri: message.meta.uri,
                     request_id: message.meta.request_id,
                     id: uuidv1({ msecs: now.getTime() }),
@@ -91,7 +92,7 @@ class OresProcessor {
                 }
             });
             return hyper.post({
-                uri: this._options.eventbus_uri,
+                uri: this._options.event_service_uri,
                 headers: {
                     'content-type': 'application/json'
                 },

--- a/test/feature/update_rules.js
+++ b/test/feature/update_rules.js
@@ -522,7 +522,7 @@ describe('update rules', function () {
     });
 
     it('Should update ORES on revision-create', () => {
-        return common.fetchEventValidator('mediawiki/revision/score')
+        return common.fetchEventValidator('mediawiki/revision/score', '1.0.0')
         .then((validate) => {
             const oresService = nock('https://ores.wikimedia.org')
             .post('/v3/precache')
@@ -548,7 +548,7 @@ describe('update rules', function () {
                     }
                 }
             });
-            const eventBusService = nock('https://eventbus.stubfortests.org')
+            const eventBusService = nock('https://eventgate.stubfortests.org')
             .post('/v1/events', function (body) {
                 if (!body || !Array.isArray(body) || !body.length) {
                     return false;
@@ -565,7 +565,7 @@ describe('update rules', function () {
     });
 
     it('Should update ORES on revision-create, error', () => {
-        return common.fetchEventValidator('mediawiki/revision/score')
+        return common.fetchEventValidator('mediawiki/revision/score', '1.0.0')
         .then((validate) => {
             const oresService = nock('https://ores.wikimedia.org')
             .post('/v3/precache')
@@ -588,7 +588,7 @@ describe('update rules', function () {
                     }
                 }
             });
-            const eventBusService = nock('https://eventbus.stubfortests.org')
+            const eventBusService = nock('https://eventgate.stubfortests.org')
             .post('/v1/events', function (body) {
                 if (!body || !Array.isArray(body) || !body.length) {
                     return false;


### PR DESCRIPTION
depends on a config change  https://gerrit.wikimedia.org/r/#/c/mediawiki/services/change-propagation/deploy/+/524055

Bug: https://phabricator.wikimedia.org/T211248