### PR TITLE
Switch internal events to eventgate.

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -477,8 +477,8 @@ spec: &spec
                   blacklist: 'html:{message.meta.uri}'
                 cases:
                   - match:
+                      $schema: '/^\/resource_change\/.*/'
                       meta:
-                        schema_uri: 'resource_change/1'
                         uri: '/https?:\/\/[^\/]+\/wiki\/(?<title>.+)/'
                       tags: [ 'transcludes' ]
                     exec:
@@ -491,8 +491,7 @@ spec: &spec
                       query:
                         redirect: false
                   - match:
-                      meta:
-                        schema_uri: 'continue/1'
+                      $schema: '/^\/change-prop\/continue\/.*/'
                     exec:
                       method: post
                       uri: '/sys/links/transcludes/{message.original_event.page_title}'
@@ -522,8 +521,8 @@ spec: &spec
                   blacklist: 'html:{message.meta.uri}'
                 cases:
                   - match:
+                      $schema: '/^\/resource_change\/.*/'
                       meta:
-                        schema_uri: 'resource_change/1'
                         uri: '/https?:\/\/[^\/]+\/wiki\/(?<title>.+)/'
                       tags: [ 'backlinks' ]
                     exec:
@@ -536,8 +535,7 @@ spec: &spec
                       query:
                         redirect: false
                   - match:
-                      meta:
-                        schema_uri: 'continue/1'
+                      $schema: '/^\/change-prop\/continue\/.*/'
                     exec:
                       method: post
                       uri: '/sys/links/backlinks/{message.original_event.page_title}'

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -529,7 +529,7 @@ class BaseExecutor {
         });
     }
 
-    retryTopicName(topic) {
+    retryStreamName(topic) {
         return `${this._hyper.config.service_name}.retry.${topic}`;
     }
 
@@ -537,15 +537,15 @@ class BaseExecutor {
         return `${this._hyper.config.service_name}#${this.rule.name}`;
     }
 
-    _errorTopicName() {
+    _errorStreamName() {
         return `${this._hyper.config.service_name}.error`;
     }
 
     _constructRetryMessage(event, errorRes, retriesLeft, retryEvent) {
         const result = {
+            $schema: '/change-prop/retry/1.0.0',
             meta: {
-                topic: this.retryTopicName(event.meta.topic || event.meta.stream),
-                schema_uri: 'retry/1',
+                stream: this.retryStreamName(event.meta.topic || event.meta.stream),
                 uri: event.meta.uri,
                 domain: event.meta.domain
             },
@@ -650,9 +650,9 @@ class BaseExecutor {
         const domain = typeof event === 'string' ? 'unknown' : event.meta.domain;
         const now = new Date();
         const errorEvent = {
+            $schema: '/error/0.0.3',
             meta: {
-                topic: this._errorTopicName(),
-                schema_uri: 'error/1',
+                stream: this._errorStreamName(),
                 uri: eventUri,
                 id: uuidv1({ msecs: now.getTime() }),
                 dt: now.toISOString(),

--- a/lib/retry_executor.js
+++ b/lib/retry_executor.js
@@ -10,7 +10,7 @@ const BaseExecutor = require('./base_executor');
 class RetryExecutor extends BaseExecutor {
     get subscribeTopics() {
         return this.rule.topics.map(topic =>
-            `${this.kafkaFactory.consumeDC}.${this.retryTopicName(topic)}`);
+            `${this.kafkaFactory.consumeDC}.${this.retryStreamName(topic)}`);
     }
 
     statName(event) {

--- a/sys/ores_updates.js
+++ b/sys/ores_updates.js
@@ -23,7 +23,6 @@ class OresProcessor {
             message.meta = Object.assign({}, message.meta);
             message.meta.topic = message.meta.stream;
         }
-        message.meta.topic = message.meta.topic || message.meta.stream;
         return P.all(this._options.ores_precache_uris.map(uri => hyper.post({
             uri,
             headers: {

--- a/test/feature/static_rules.js
+++ b/test/feature/static_rules.js
@@ -154,7 +154,7 @@ describe('Basic rule management', function () {
         .then((retryConsumer) => {
             setTimeout(() => producer.produce('test_dc.simple_test_rule', 0,
                 Buffer.from(JSON.stringify(common.eventWithMessageAndRandom('test', random)))), 2000);
-            return common.fetchEventValidator('change-prop/retry')
+            return common.fetchEventValidator('change-prop/retry', '1.0.0')
             .then((validate) => {
                 function check() {
                     return retryConsumer.consumeAsync(1)
@@ -286,7 +286,7 @@ describe('Basic rule management', function () {
             setTimeout(() =>
                 producer.produce('test_dc.simple_test_rule', 0, Buffer.from('not_a_json_message')), 2000);
 
-            return common.fetchEventValidator('error')
+            return common.fetchEventValidator('error', '0.0.3')
             .then((validate) => {
                 function check() {
                     return errorConsumer.consumeAsync(1)


### PR DESCRIPTION
This is step 1 of the process. We will still have `.meta.topic` events in the queue when we deploy this, so we need to still maintain backward compatibility and for the job queue use-case.

Config change: https://gerrit.wikimedia.org/r/#/c/mediawiki/services/change-propagation/deploy/+/524937
Bug: https://phabricator.wikimedia.org/T228318

cc @ottomata 