### PR TITLE
Change-Prop consumer group must respect service name (T244387)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@ npm-debug.log*
 /Dockerfile
 LICENSE
 README.md
+config.yaml

--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -107,7 +107,7 @@ class BaseExecutor {
     }
 
     subscribe() {
-        const prefix = this.options.test_mode ? 'test-change-prop' : 'change-prop';
+        const prefix = this.options.test_mode ? `test-${this._hyper.config.service_name}` : `${this._hyper.config.service_name}`;
         return this.kafkaFactory.createConsumer(
             `${prefix}-${this.rule.name}`,
             this.subscribeTopics,


### PR DESCRIPTION
Changed the hard-coded group name to the service name as specified in the config. Also excludes config.yaml from docker image.