### PR TITLE
Changed consumer group name to use service name instead of hard-coded string

### DIFF
--- a/lib/base_executor.js
+++ b/lib/base_executor.js
@@ -107,7 +107,7 @@ class BaseExecutor {
     }
 
     subscribe() {
-        const prefix = this.options.test_mode ? 'test-change-prop' : 'change-prop';
+        const prefix = this.options.test_mode ? `test-${this._hyper.config.service_name}` : `${this._hyper.config.service_name}`;
         return this.kafkaFactory.createConsumer(
             `${prefix}-${this.rule.name}`,
             this.subscribeTopics,


### PR DESCRIPTION
Transferring the commit that has been merged in k8s branch.

Bug: T244387