### PR TITLE
Add libsasl2

### DIFF
--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -4,6 +4,7 @@ lives:
   in: /srv/service
 runs:
   environment: { APP_BASE_PATH: /srv/service }
+apt: { packages: [libsasl2-2] }
 
 variants:
   build:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "change-propagation",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Listens to events from Kafka and delivers them",
   "main": "server.js",
   "repository": {


### PR DESCRIPTION
Previously libsasl2 was installed as a side effect of installing
librdkafka. Now that we've removed it from our container base,
libsasl2 doesn't get installed and we can't invoke librdkafka.

Error: https://phabricator.wikimedia.org/P11532