### PR TITLE
Blubber: depend on libssl and not libsasl

### DIFF
--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -4,11 +4,11 @@ lives:
   in: /srv/service
 runs:
   environment: { APP_BASE_PATH: /srv/service }
-apt: { packages: [libsasl2-2] }
+apt: { packages: [libssl1.1] }
 
 variants:
   build:
-    apt: { packages: [build-essential, python-dev, git, libsasl2-dev] }
+    apt: { packages: [build-essential, python-dev, git, libssl-dev] }
     base: docker-registry.wikimedia.org/nodejs10-devel
     copies: [local]
     node: { requirements: [package.json]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "change-propagation",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Listens to events from Kafka and delivers them",
   "main": "server.js",
   "repository": {


### PR DESCRIPTION
Now that we're building librdkafka from sources, we need proper dependencies for the features we use. See https://github.com/edenhill/librdkafka#requirements for the requirements. I think we're only using ssl support, thus we only need libssl-dev for the build target and libssl for runtime.